### PR TITLE
deps: migrate Android JNI to 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,12 +254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,7 +498,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -1249,27 +1243,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1790,7 +1789,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1812,7 +1811,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2021,6 +2020,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2156,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +2277,22 @@ dependencies = [
  "digest",
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2394,31 +2424,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.19",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2676,7 +2686,7 @@ dependencies = [
  "flume",
  "heapless",
  "smoltcp",
- "thiserror 2.0.19",
+ "thiserror",
  "tracing",
 ]
 
@@ -2741,7 +2751,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2788,7 +2798,7 @@ dependencies = [
  "sha2",
  "subtle",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tracing",
  "usque-protocol",
@@ -2812,7 +2822,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2835,7 +2845,7 @@ dependencies = [
  "prost-build",
  "protoc-bin-vendored",
  "serde",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -2845,7 +2855,7 @@ dependencies = [
  "async-trait",
  "security-framework",
  "serde",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "uuid",
  "windows-sys 0.61.2",
@@ -2860,7 +2870,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -2879,7 +2889,7 @@ dependencies = [
  "quiche",
  "rustls",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tokio-boring",
  "tokio-rustls",
@@ -3154,20 +3164,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3176,7 +3177,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3190,40 +3191,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3233,21 +3213,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3263,21 +3231,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3287,21 +3243,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ http-body-util = "0.1.4"
 hyper = { version = "1.11.0", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1.20", features = ["tokio"] }
 ipnet = { version = "2.11.0", features = ["serde"] }
-jni = "0.21.1"
+jni = "0.22.4"
 libc = "0.2.189"
 p256 = { version = "0.14.0", features = ["pem", "pkcs8"] }
 prost = "0.14.1"

--- a/crates/usque-android/src/lib.rs
+++ b/crates/usque-android/src/lib.rs
@@ -17,8 +17,12 @@ use std::{
 };
 
 use jni::{
-    JNIEnv, JavaVM,
-    objects::{GlobalRef, JByteArray, JClass, JObject, JObjectArray, JString, JValue},
+    Env, EnvUnowned, JValue, JavaVM,
+    errors::ThrowRuntimeExAndDefault,
+    jni_sig, jni_str,
+    objects::{JByteArray, JClass, JObject, JObjectArray, JString},
+    refs::Global,
+    strings::JNIString,
     sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jstring},
 };
 use serde::{Deserialize, Serialize};
@@ -43,28 +47,74 @@ pub const START_PLATFORM_FAILURE: i32 = -6;
 pub const START_TRANSPORT_FAILURE: i32 = -7;
 pub const START_TUN_FAILURE: i32 = -8;
 
-#[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeIsReady(
-    _environment: JNIEnv<'_>,
-    _class: JClass<'_>,
-) -> jboolean {
-    if engine_ready() { JNI_TRUE } else { JNI_FALSE }
+#[derive(Debug)]
+struct JniCode(jint);
+
+impl Default for JniCode {
+    fn default() -> Self {
+        Self(START_PLATFORM_FAILURE)
+    }
+}
+
+fn with_jni_env<'local, T, F>(environment: &mut EnvUnowned<'local>, operation: F) -> T
+where
+    T: Default + 'local,
+    F: FnOnce(&mut Env<'local>) -> T,
+{
+    environment
+        .with_env(|environment| -> jni::errors::Result<T> { Ok(operation(environment)) })
+        .resolve::<ThrowRuntimeExAndDefault>()
+}
+
+fn with_jni_code<'local, F>(environment: &mut EnvUnowned<'local>, operation: F) -> jint
+where
+    F: FnOnce(&mut Env<'local>) -> jint,
+{
+    with_jni_env(environment, |environment| JniCode(operation(environment))).0
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeStart(
-    mut environment: JNIEnv<'_>,
-    _class: JClass<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeIsReady<'local>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
+) -> jboolean {
+    with_jni_env(&mut environment, |_| {
+        if engine_ready() { JNI_TRUE } else { JNI_FALSE }
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeStart<'local>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
     tun_file_descriptor: jint,
-    profile_json: JString<'_>,
-    warp_secret: JByteArray<'_>,
-    vpn_service: JObject<'_>,
+    profile_json: JString<'local>,
+    warp_secret: JByteArray<'local>,
+    vpn_service: JObject<'local>,
+) -> jint {
+    with_jni_code(&mut environment, |environment| {
+        native_start(
+            environment,
+            tun_file_descriptor,
+            profile_json,
+            warp_secret,
+            vpn_service,
+        )
+    })
+}
+
+fn native_start<'local>(
+    environment: &mut Env<'local>,
+    tun_file_descriptor: jint,
+    profile_json: JString<'local>,
+    warp_secret: JByteArray<'local>,
+    vpn_service: JObject<'local>,
 ) -> jint {
     if tun_file_descriptor < 0 || !engine_ready() {
         return START_NOT_READY;
     }
-    let profile_json = match environment.get_string(&profile_json) {
-        Ok(value) => value.to_string_lossy().into_owned(),
+    let profile_json = match profile_json.try_to_string(environment) {
+        Ok(value) => value,
         Err(_) => return START_INVALID_PROFILE,
     };
     let secret = match environment.convert_byte_array(&warp_secret) {
@@ -84,7 +134,12 @@ pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeSta
         Err(_) => return START_PLATFORM_FAILURE,
     };
     let network_generation = environment
-        .call_method(&vpn_service, "getUnderlyingNetworkGeneration", "()J", &[])
+        .call_method(
+            &vpn_service,
+            jni_str!("getUnderlyingNetworkGeneration"),
+            jni_sig!("()J"),
+            &[],
+        )
         .and_then(|value| value.j())
         .unwrap_or_default()
         .max(0) as u64;
@@ -106,18 +161,29 @@ pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeSta
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeStartProxy(
-    mut environment: JNIEnv<'_>,
-    _class: JClass<'_>,
-    profile_json: JString<'_>,
-    warp_secret: JByteArray<'_>,
-    vpn_service: JObject<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeStartProxy<'local>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    profile_json: JString<'local>,
+    warp_secret: JByteArray<'local>,
+    vpn_service: JObject<'local>,
+) -> jint {
+    with_jni_code(&mut environment, |environment| {
+        native_start_proxy(environment, profile_json, warp_secret, vpn_service)
+    })
+}
+
+fn native_start_proxy<'local>(
+    environment: &mut Env<'local>,
+    profile_json: JString<'local>,
+    warp_secret: JByteArray<'local>,
+    vpn_service: JObject<'local>,
 ) -> jint {
     if !engine_ready() {
         return START_NOT_READY;
     }
-    let profile_json = match environment.get_string(&profile_json) {
-        Ok(value) => value.to_string_lossy().into_owned(),
+    let profile_json = match profile_json.try_to_string(environment) {
+        Ok(value) => value,
         Err(_) => return START_INVALID_PROFILE,
     };
     let secret = match environment.convert_byte_array(&warp_secret) {
@@ -144,7 +210,12 @@ pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeSta
         Err(_) => return START_PLATFORM_FAILURE,
     };
     let network_generation = environment
-        .call_method(&vpn_service, "getUnderlyingNetworkGeneration", "()J", &[])
+        .call_method(
+            &vpn_service,
+            jni_str!("getUnderlyingNetworkGeneration"),
+            jni_sig!("()J"),
+            &[],
+        )
         .and_then(|value| value.j())
         .unwrap_or_default()
         .max(0) as u64;
@@ -165,38 +236,50 @@ pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeSta
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeCancel(
-    _environment: JNIEnv<'_>,
-    _class: JClass<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeCancel<'local>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
 ) {
-    cancel_engine();
+    with_jni_env(&mut environment, |_| cancel_engine());
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeStop(
-    _environment: JNIEnv<'_>,
-    _class: JClass<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeStop<'local>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
 ) {
-    stop_engine();
+    with_jni_env(&mut environment, |_| stop_engine());
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeNotifyNetworkChanged(
-    _environment: JNIEnv<'_>,
-    _class: JClass<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeNotifyNetworkChanged<
+    'local,
+>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
     generation: jlong,
 ) {
-    if generation >= 0 {
-        notify_network_changed(generation as u64);
-    }
+    with_jni_env(&mut environment, |_| {
+        if generation >= 0 {
+            notify_network_changed(generation as u64);
+        }
+    });
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeValidateWarpSecret(
-    environment: JNIEnv<'_>,
-    _class: JClass<'_>,
-    secret: JByteArray<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeValidateWarpSecret<
+    'local,
+>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    secret: JByteArray<'local>,
 ) -> jint {
+    with_jni_code(&mut environment, |environment| {
+        native_validate_warp_secret(environment, secret)
+    })
+}
+
+fn native_validate_warp_secret(environment: &mut Env<'_>, secret: JByteArray<'_>) -> jint {
     let bytes = match environment.convert_byte_array(&secret) {
         Ok(bytes) => Zeroizing::new(bytes),
         Err(_) => return INVALID_WARP_SECRET,
@@ -205,11 +288,19 @@ pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeVal
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeInspectWarpSecret(
-    mut environment: JNIEnv<'_>,
-    _class: JClass<'_>,
-    secret: JByteArray<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeInspectWarpSecret<
+    'local,
+>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    secret: JByteArray<'local>,
 ) -> jstring {
+    with_jni_env(&mut environment, |environment| {
+        native_inspect_warp_secret(environment, secret)
+    })
+}
+
+fn native_inspect_warp_secret(environment: &mut Env<'_>, secret: JByteArray<'_>) -> jstring {
     let bytes = match environment.convert_byte_array(&secret) {
         Ok(bytes) => Zeroizing::new(bytes),
         Err(_) => return std::ptr::null_mut(),
@@ -217,7 +308,8 @@ pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeIns
     let metadata = match identity_metadata(&bytes) {
         Ok(metadata) => metadata,
         Err(error) => {
-            let _ = environment.throw_new("java/lang/IllegalArgumentException", error);
+            let error = JNIString::from(error);
+            let _ = environment.throw_new(jni_str!("java/lang/IllegalArgumentException"), &error);
             return std::ptr::null_mut();
         }
     };
@@ -232,10 +324,14 @@ pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeIns
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeSnapshot(
-    environment: JNIEnv<'_>,
-    _class: JClass<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeSnapshot<'local>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
 ) -> jstring {
+    with_jni_env(&mut environment, native_snapshot)
+}
+
+fn native_snapshot(environment: &mut Env<'_>) -> jstring {
     let json = serde_json::to_string(&engine_snapshot()).unwrap_or_else(|_| {
         r#"{"phase":"error","warning":"Native status serialization failed."}"#.to_owned()
     });
@@ -246,146 +342,192 @@ pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeSna
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeRegisterConsumerWarp(
-    mut environment: JNIEnv<'_>,
-    _class: JClass<'_>,
-    locale: JString<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeRegisterConsumerWarp<
+    'local,
+>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    locale: JString<'local>,
 ) -> jbyteArray {
-    let locale = match environment.get_string(&locale) {
-        Ok(locale) => locale.to_string_lossy().into_owned(),
+    with_jni_env(&mut environment, |environment| {
+        native_register_consumer_warp(environment, locale)
+    })
+}
+
+fn native_register_consumer_warp(environment: &mut Env<'_>, locale: JString<'_>) -> jbyteArray {
+    let locale = match locale.try_to_string(environment) {
+        Ok(locale) => locale,
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             return std::ptr::null_mut();
         }
     };
     let secret = match register_consumer_warp(&locale) {
         Ok(secret) => secret,
         Err(error) => {
-            throw_io_error(&mut environment, &error);
+            throw_io_error(environment, &error);
             return std::ptr::null_mut();
         }
     };
     match environment.byte_array_from_slice(secret.as_bytes()) {
         Ok(output) => output.into_raw(),
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             std::ptr::null_mut()
         }
     }
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeRegisterConsumerWarpWithLicense(
-    mut environment: JNIEnv<'_>,
-    _class: JClass<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeRegisterConsumerWarpWithLicense<
+    'local,
+>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    locale: JString<'local>,
+    license_key: JString<'local>,
+) -> jbyteArray {
+    with_jni_env(&mut environment, |environment| {
+        native_register_consumer_warp_with_license(environment, locale, license_key)
+    })
+}
+
+fn native_register_consumer_warp_with_license(
+    environment: &mut Env<'_>,
     locale: JString<'_>,
     license_key: JString<'_>,
 ) -> jbyteArray {
-    let locale = match environment.get_string(&locale) {
-        Ok(locale) => locale.to_string_lossy().into_owned(),
+    let locale = match locale.try_to_string(environment) {
+        Ok(locale) => locale,
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             return std::ptr::null_mut();
         }
     };
-    let license_key = match environment.get_string(&license_key) {
-        Ok(value) => Zeroizing::new(value.to_string_lossy().into_owned()),
+    let license_key = match license_key.try_to_string(environment) {
+        Ok(value) => Zeroizing::new(value),
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             return std::ptr::null_mut();
         }
     };
     let secret = match register_consumer_warp_with_license(&locale, license_key.as_str()) {
         Ok(secret) => secret,
         Err(error) => {
-            throw_io_error(&mut environment, &error);
+            throw_io_error(environment, &error);
             return std::ptr::null_mut();
         }
     };
     match environment.byte_array_from_slice(secret.as_bytes()) {
         Ok(output) => output.into_raw(),
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             std::ptr::null_mut()
         }
     }
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeUnbindConsumerWarp(
-    mut environment: JNIEnv<'_>,
-    _class: JClass<'_>,
-    warp_secret: JByteArray<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeUnbindConsumerWarp<
+    'local,
+>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    warp_secret: JByteArray<'local>,
 ) -> jint {
+    with_jni_code(&mut environment, |environment| {
+        native_unbind_consumer_warp(environment, warp_secret)
+    })
+}
+
+fn native_unbind_consumer_warp(environment: &mut Env<'_>, warp_secret: JByteArray<'_>) -> jint {
     let secret = match environment.convert_byte_array(&warp_secret) {
         Ok(value) => Zeroizing::new(value),
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             return INVALID_WARP_SECRET;
         }
     };
     match unbind_consumer_warp(&secret) {
         Ok(()) => START_OK,
         Err(error) => {
-            throw_io_error(&mut environment, &error);
+            throw_io_error(environment, &error);
             START_PLATFORM_FAILURE
         }
     }
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeCheckForUpdates(
-    mut environment: JNIEnv<'_>,
-    _class: JClass<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeCheckForUpdates<
+    'local,
+>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
 ) -> jstring {
+    with_jni_env(&mut environment, native_check_for_updates)
+}
+
+fn native_check_for_updates(environment: &mut Env<'_>) -> jstring {
     let result = match check_for_updates() {
         Ok(result) => result,
         Err(error) => {
-            throw_io_error(&mut environment, &error);
+            throw_io_error(environment, &error);
             return std::ptr::null_mut();
         }
     };
     match environment.new_string(result) {
         Ok(output) => output.into_raw(),
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             std::ptr::null_mut()
         }
     }
 }
 
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeApplyProfileCommand(
-    mut environment: JNIEnv<'_>,
-    _class: JClass<'_>,
+pub extern "system" fn Java_io_github_georgexie2333_usque_NativeEngine_nativeApplyProfileCommand<
+    'local,
+>(
+    mut environment: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    config_path: JString<'local>,
+    request_json: JString<'local>,
+) -> jstring {
+    with_jni_env(&mut environment, |environment| {
+        native_apply_profile_command(environment, config_path, request_json)
+    })
+}
+
+fn native_apply_profile_command(
+    environment: &mut Env<'_>,
     config_path: JString<'_>,
     request_json: JString<'_>,
 ) -> jstring {
-    let config_path = match environment.get_string(&config_path) {
-        Ok(value) => value.to_string_lossy().into_owned(),
+    let config_path = match config_path.try_to_string(environment) {
+        Ok(value) => value,
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             return std::ptr::null_mut();
         }
     };
-    let request_json = match environment.get_string(&request_json) {
-        Ok(value) => value.to_string_lossy().into_owned(),
+    let request_json = match request_json.try_to_string(environment) {
+        Ok(value) => value,
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             return std::ptr::null_mut();
         }
     };
     let result = match apply_profile_command(&config_path, &request_json) {
         Ok(result) => result,
         Err(error) => {
-            throw_io_error(&mut environment, &error);
+            throw_io_error(environment, &error);
             return std::ptr::null_mut();
         }
     };
     match environment.new_string(result) {
         Ok(output) => output.into_raw(),
         Err(error) => {
-            throw_io_error(&mut environment, &error.to_string());
+            throw_io_error(environment, &error.to_string());
             std::ptr::null_mut()
         }
     }
@@ -904,7 +1046,7 @@ fn listener_for_family(listeners: &[SocketAddr], ipv4: bool) -> SocketAddr {
 
 struct AndroidSocketProtector {
     java_vm: JavaVM,
-    service: GlobalRef,
+    service: Global<JObject<'static>>,
     policy: AndroidSocketRoutePolicy,
     network_generation: AtomicU64,
 }
@@ -931,36 +1073,43 @@ impl SocketProtector for AndroidSocketProtector {
     fn protect(&self, socket: SocketHandle) -> Result<(), String> {
         let descriptor = jint::try_from(socket.value())
             .map_err(|_| "endpoint socket descriptor is out of range".to_owned())?;
-        let mut environment = self
+        let (protected, network) = self
             .java_vm
-            .attach_current_thread()
+            .attach_current_thread(|environment| -> jni::errors::Result<_> {
+                let protected = if self.policy.requires_vpn_protection() {
+                    environment
+                        .call_method(
+                            &self.service,
+                            jni_str!("protect"),
+                            jni_sig!("(I)Z"),
+                            &[JValue::Int(descriptor)],
+                        )
+                        .and_then(|value| value.z())?
+                } else {
+                    true
+                };
+
+                #[cfg(target_os = "android")]
+                let network = environment
+                    .call_method(
+                        &self.service,
+                        jni_str!("getUnderlyingNetworkHandle"),
+                        jni_sig!("()J"),
+                        &[],
+                    )
+                    .and_then(|value| value.j())?;
+                #[cfg(not(target_os = "android"))]
+                let network = 0;
+
+                Ok((protected, network))
+            })
             .map_err(|error| format!("attach VpnService protector thread: {error}"))?;
-        if self.policy.requires_vpn_protection() {
-            let protected = environment
-                .call_method(
-                    self.service.as_obj(),
-                    "protect",
-                    "(I)Z",
-                    &[JValue::Int(descriptor)],
-                )
-                .and_then(|value| value.z())
-                .map_err(|error| format!("VpnService.protect failed: {error}"))?;
-            if !protected {
-                return Err("VpnService.protect rejected the endpoint socket".to_owned());
-            }
+        if !protected {
+            return Err("VpnService.protect rejected the endpoint socket".to_owned());
         }
 
         #[cfg(target_os = "android")]
         {
-            let network = environment
-                .call_method(
-                    self.service.as_obj(),
-                    "getUnderlyingNetworkHandle",
-                    "()J",
-                    &[],
-                )
-                .and_then(|value| value.j())
-                .map_err(|error| format!("read Android underlying network: {error}"))?;
             if network <= 0 {
                 return Err("Android has no selected non-VPN physical network".to_owned());
             }
@@ -975,14 +1124,24 @@ impl SocketProtector for AndroidSocketProtector {
                 ));
             }
         }
+        #[cfg(not(target_os = "android"))]
+        let _ = network;
         Ok(())
     }
 
     fn endpoint_family_available(&self, endpoint: SocketAddr) -> Option<bool> {
-        let mut environment = self.java_vm.attach_current_thread().ok()?;
-        let mask = environment
-            .call_method(self.service.as_obj(), "getUnderlyingFamilyMask", "()I", &[])
-            .and_then(|value| value.i())
+        let mask = self
+            .java_vm
+            .attach_current_thread(|environment| -> jni::errors::Result<_> {
+                environment
+                    .call_method(
+                        &self.service,
+                        jni_str!("getUnderlyingFamilyMask"),
+                        jni_sig!("()I"),
+                        &[],
+                    )
+                    .and_then(|value| value.i())
+            })
             .ok()?;
         if mask == 0 {
             return None;
@@ -999,37 +1158,32 @@ impl SocketProtector for AndroidSocketProtector {
     }
 
     fn resolve(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>, String> {
-        let mut environment = self
+        let resolved = self
             .java_vm
-            .attach_current_thread()
-            .map_err(|error| format!("attach Android resolver thread: {error}"))?;
-        let host = environment
-            .new_string(host)
-            .map_err(|error| format!("create Android resolver host: {error}"))?;
-        let host_object = JObject::from(host);
-        let resolved = environment
-            .call_method(
-                self.service.as_obj(),
-                "resolveUnderlyingHost",
-                "(Ljava/lang/String;)[Ljava/lang/String;",
-                &[JValue::Object(&host_object)],
-            )
-            .and_then(|value| value.l())
+            .attach_current_thread(|environment| -> jni::errors::Result<Vec<String>> {
+                let host = environment.new_string(host)?;
+                let host_object = JObject::from(host);
+                let resolved = environment
+                    .call_method(
+                        &self.service,
+                        jni_str!("resolveUnderlyingHost"),
+                        jni_sig!("(Ljava/lang/String;)[Ljava/lang/String;"),
+                        &[JValue::Object(&host_object)],
+                    )?
+                    .l()?;
+                let resolved =
+                    environment.cast_local::<JObjectArray<JString<'static>>>(resolved)?;
+                let length = resolved.len(environment)?;
+                let mut values = Vec::with_capacity(length);
+                for index in 0..length {
+                    let value = resolved.get_element(environment, index)?;
+                    values.push(value.try_to_string(environment)?);
+                }
+                Ok(values)
+            })
             .map_err(|error| format!("resolve on Android underlying network: {error}"))?;
-        let resolved = JObjectArray::from(resolved);
-        let length = environment
-            .get_array_length(&resolved)
-            .map_err(|error| format!("read Android resolver result: {error}"))?;
-        let mut addresses = Vec::with_capacity(length as usize);
-        for index in 0..length {
-            let value = environment
-                .get_object_array_element(&resolved, index)
-                .map_err(|error| format!("read Android resolver address: {error}"))?;
-            let value = JString::from(value);
-            let value = environment
-                .get_string(&value)
-                .map_err(|error| format!("decode Android resolver address: {error}"))?;
-            let value = value.to_string_lossy();
+        let mut addresses = Vec::with_capacity(resolved.len());
+        for value in resolved {
             if let Ok(ip) = value
                 .split('%')
                 .next()
@@ -1065,30 +1219,26 @@ impl AndroidEndpointPinRefresher {
         let portable = identity
             .to_portable_secret_json()
             .map_err(|error| TransportError::EndpointPinRefresh(error.to_string()))?;
-        let mut environment = self
+        let persisted = self
             .protector
             .java_vm
-            .attach_current_thread()
-            .map_err(|error| TransportError::EndpointPinRefresh(error.to_string()))?;
-        let profile_id = environment
-            .new_string(&self.profile_id)
-            .map_err(|error| TransportError::EndpointPinRefresh(error.to_string()))?;
-        let secret = environment
-            .byte_array_from_slice(portable.as_bytes())
-            .map_err(|error| TransportError::EndpointPinRefresh(error.to_string()))?;
-        let profile_object = JObject::from(profile_id);
-        let secret_object = JObject::from(secret);
-        let persisted = environment
-            .call_method(
-                self.protector.service.as_obj(),
-                "persistRefreshedWarpIdentity",
-                "(Ljava/lang/String;[B)Z",
-                &[
-                    JValue::Object(&profile_object),
-                    JValue::Object(&secret_object),
-                ],
-            )
-            .and_then(|value| value.z())
+            .attach_current_thread(|environment| -> jni::errors::Result<_> {
+                let profile_id = environment.new_string(&self.profile_id)?;
+                let secret = environment.byte_array_from_slice(portable.as_bytes())?;
+                let profile_object = JObject::from(profile_id);
+                let secret_object = JObject::from(secret);
+                environment
+                    .call_method(
+                        &self.protector.service,
+                        jni_str!("persistRefreshedWarpIdentity"),
+                        jni_sig!("(Ljava/lang/String;[B)Z"),
+                        &[
+                            JValue::Object(&profile_object),
+                            JValue::Object(&secret_object),
+                        ],
+                    )
+                    .and_then(|value| value.z())
+            })
             .map_err(|error| TransportError::EndpointPinRefresh(error.to_string()))?;
         if persisted {
             Ok(())
@@ -2019,14 +2169,20 @@ fn check_for_updates() -> Result<String, String> {
     serde_json::to_string(&result).map_err(|error| error.to_string())
 }
 
-fn throw_io_error(environment: &mut JNIEnv<'_>, message: &str) {
+fn throw_io_error(environment: &mut Env<'_>, message: &str) {
     let message: String = message.chars().take(512).collect();
-    let _ = environment.throw_new("java/io/IOException", message);
+    let message = JNIString::from(message);
+    let _ = environment.throw_new(jni_str!("java/io/IOException"), &message);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn jni_boundary_failure_default_never_reports_success() {
+        assert_eq!(JniCode::default().0, START_PLATFORM_FAILURE);
+    }
 
     #[test]
     fn proxy_socket_routing_does_not_require_vpn_permission() {


### PR DESCRIPTION
## Summary

Migrate the Android native bridge from jni 0.21 to jni 0.22 and adapt ownership, mutable environment access, local references, Java string conversion, and array handling to the stricter API. This is the reviewed replacement for Dependabot PR #8.

## Change scope

- Platforms: Android / Android TV
- Outputs: VPN / SOCKS5 / HTTP Android JNI bridge
- Security or privileged-state impact: JNI boundary and Android socket/VpnService callbacks retain fail-closed error propagation; no Windows privileged-state change.

## Validation

- [x] Relevant format, lint, and unit tests pass.
- [x] Protocol or parser changes include malformed-input/interoperability coverage. (Not applicable: JNI API migration only.)
- [x] Privileged network changes include isolated cleanup and leak-prevention evidence. (No policy change; callback failures remain fail closed.)
- [x] UI changes cover English/Chinese, themes, focus, scaling, and TV navigation as applicable. (Not applicable: no Flutter UI change.)
- [x] New logs, errors, and diagnostics were reviewed for sensitive data.
- [x] Documentation and lockfiles are updated where required.

Validated with the checked-in Windows Rust test/Clippy helper and Android arm64 Release build path. GitHub PR Check, CI, and Build provide the final clean-run evidence.

## Not tested

No VPN/TUN/WFP runtime test was run on the development host. Android VPN behavior remains reserved for isolated devices per repository safety policy.

## Checklist

- [x] The PR title follows Conventional Commits.
- [x] No signing key, WARP Secret, token, license, device ID, endpoint pin, diagnostic bundle, or generated package is committed.
- [x] This change does not add WebView UI, insecure TLS, automatic telemetry, or automatic diagnostic upload.
- [x] I read CONTRIBUTING.md, SECURITY.md, and the Code of Conduct.