### PR TITLE
fix(ci): isolate retry test from platform defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `v0.1.1-beta.2` release is blocked until every declared target passes instal
 | Windows | MSI | Windows 10 22H2, build 19045 | x86-64-v2 |
 | Android / Android TV | APK | Android 8.0, API 26 | arm64-v8a |
 
-macOS remains a future source target and is not a build or release gate. Linux, iOS, Zero Trust, application stores, a public CLI, and multipath bandwidth aggregation are outside this beta.
+macOS remains a future source target and is not a build or release gate. iOS, Zero Trust, application stores, a public CLI, and multipath bandwidth aggregation are outside this beta.
 
 ## Highlights
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,7 +33,7 @@ Usque 是独立项目，与 Cloudflare 无隶属、赞助或背书关系。Cloud
 | Windows | MSI | Windows 10 22H2，Build 19045 | x86-64-v2 |
 | Android / Android TV | APK | Android 8.0，API 26 | arm64-v8a |
 
-macOS 保留为后续源码目标，但不参与当前构建或发布门禁。本 Beta 不支持 Linux、iOS、Zero Trust、应用商店、公开 CLI 或多路径带宽聚合。
+macOS 保留为后续源码目标，但不参与当前构建或发布门禁。本 Beta 不支持 iOS、Zero Trust、应用商店、公开 CLI 或多路径带宽聚合。
 
 ## 主要功能
 

--- a/apps/usque_gui/windows/CMakeLists.txt
+++ b/apps/usque_gui/windows/CMakeLists.txt
@@ -59,9 +59,9 @@ include(flutter/generated_plugins.cmake)
 
 
 # === Installation ===
-# Support files are copied into place next to the executable, so that it can
-# run in place. This is done instead of making a separate bundle (as on Linux)
-# so that building and running from within Visual Studio will work.
+# Support files are copied into place next to the executable so it can run in
+# place without a separate bundle directory, allowing Visual Studio builds to
+# run directly.
 set(BUILD_BUNDLE_DIR "$<TARGET_FILE_DIR:${BINARY_NAME}>")
 # Make the "install" step default, as it's required to run.
 set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)

--- a/crates/usque-engine/src/lib.rs
+++ b/crates/usque-engine/src/lib.rs
@@ -2786,6 +2786,23 @@ mod tests {
         let service =
             ControlService::open_with_vault(ConfigStore::new(&config_path), vault.clone()).unwrap();
 
+        let mut retry_profile = service
+            .config_snapshot()
+            .await
+            .active_profile()
+            .cloned()
+            .expect("active profile");
+        retry_profile.mode = OperatingMode::Socks5;
+        retry_profile.frontends = FrontendSettings {
+            tunnel: false,
+            socks5: true,
+            http: true,
+        };
+        service
+            .upsert_profile(retry_profile)
+            .await
+            .expect("save proxy-only retry profile");
+
         let retry = service
             .handle(request(
                 "retry",


### PR DESCRIPTION
## Summary

- Save an explicit proxy-only profile before Retry so the regression test reaches `MISSING_CREDENTIAL` on every CI host.
- Remove Linux from the English and Chinese GUI product-scope text.
- Reword the Windows CMake bundle comment without a Linux reference.
- Keep production defaults, non-Windows TUN fail-closed behavior, public interfaces, schemas, and persisted formats unchanged.

## Change scope

- Platforms: shared Rust test plus Windows GUI build comments and bilingual documentation
- Outputs: no production output changes; test fixture enables SOCKS5/HTTP and disables TUN
- Security or privileged-state impact: None. This is test setup and documentation only.

## Validation

- [x] Relevant format, lint, and unit tests pass.
  - `cargo fmt --all -- --check`
  - `python tool/check_repository_policy.py`
  - `.\tool\build_windows_rust_release.ps1 -Variant x64-v2 -CargoAction clippy`
  - `cargo test --locked --package usque-engine --lib tests::retry_and_clear_all_data_are_real_control_operations -- --exact`
  - `cargo test --locked --package usque-engine --all-targets`
  - `cargo test --workspace --all-targets --locked`
- [x] Protocol or parser changes include malformed-input/interoperability coverage. N/A: no protocol or parser change.
- [x] Privileged network changes include isolated cleanup and leak-prevention evidence. N/A: no privileged network change.
- [x] UI changes cover English/Chinese, themes, focus, scaling, and TV navigation as applicable. N/A: no runtime UI change; both READMEs were updated.
- [x] New logs, errors, and diagnostics were reviewed for sensitive data. N/A: none added.
- [x] Documentation and lockfiles are updated where required. Both READMEs are updated; no lockfile change is required.
- [x] Flutter `.metadata` has no Linux platform entry and no `apps/usque_gui/linux/` path is tracked.

## Not tested

- Flutter analyze/test were intentionally left to the complete CI workflow.
- The Ubuntu-specific regression path will be confirmed by the PR's `Rust format, lint, and tests` job.

## Checklist

- [x] The PR title follows Conventional Commits.
- [x] No signing key, WARP Secret, token, license, device ID, endpoint pin, diagnostic bundle, or generated package is committed.
- [x] This change does not add WebView UI, insecure TLS, automatic telemetry, or automatic diagnostic upload.
- [x] I read `CONTRIBUTING.md`, `SECURITY.md`, and the Code of Conduct.
