### PR TITLE
fix(release): verify self-signed Windows artifacts without trust import

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,15 +234,6 @@ jobs:
             throw "PFX signer does not match protected WINDOWS_SIGNER_SHA256."
           }
 
-          $cer = Join-Path $env:RUNNER_TEMP "usque-signing.cer"
-          Export-Certificate -Cert $certificate -FilePath $cer | Out-Null
-          Import-Certificate `
-            -FilePath $cer `
-            -CertStoreLocation Cert:\CurrentUser\Root | Out-Null
-          Import-Certificate `
-            -FilePath $cer `
-            -CertStoreLocation Cert:\CurrentUser\TrustedPublisher | Out-Null
-
           $toolArch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
             "arm64"
           } else {
@@ -288,10 +279,10 @@ jobs:
             if ($LASTEXITCODE -ne 0) {
               throw "Signing failed for $($binary.FullName)."
             }
-            & $env:USQUE_SIGNTOOL verify /pa /all /v $binary.FullName
-            if ($LASTEXITCODE -ne 0) {
-              throw "Signature verification failed for $($binary.FullName)."
-            }
+            & ./tool/verify_windows_authenticode.ps1 `
+              -Path $binary.FullName `
+              -SignerSha256 $env:WINDOWS_SIGNER_SHA256 `
+              -AllowPinnedUntrustedRoot | Out-Null
           }
 
       - name: Build, inspect, and ICE-validate MSI
@@ -304,7 +295,8 @@ jobs:
             -AppDirectory $payload `
             -OutputDirectory $output `
             -SignerSha256 $env:WINDOWS_SIGNER_SHA256 `
-            -Version $env:RELEASE_TAG
+            -Version $env:RELEASE_TAG `
+            -AllowPinnedUntrustedRoot
 
       - name: Sign and verify MSI
         shell: pwsh
@@ -322,8 +314,10 @@ jobs:
             /td SHA256 `
             $msi.FullName
           if ($LASTEXITCODE -ne 0) { throw "MSI signing failed." }
-          & $env:USQUE_SIGNTOOL verify /pa /all /v $msi.FullName
-          if ($LASTEXITCODE -ne 0) { throw "MSI signature verification failed." }
+          & ./tool/verify_windows_authenticode.ps1 `
+            -Path $msi.FullName `
+            -SignerSha256 $env:WINDOWS_SIGNER_SHA256 `
+            -AllowPinnedUntrustedRoot | Out-Null
 
       - name: Attest Windows build provenance
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -344,20 +338,14 @@ jobs:
         run: |
           $thumbprint = $env:USQUE_CERT_THUMBPRINT
           if (-not [string]::IsNullOrWhiteSpace($thumbprint)) {
-            foreach ($store in @("My", "Root", "TrustedPublisher")) {
-              $path = "Cert:\CurrentUser\$store\$thumbprint"
-              if (Test-Path -LiteralPath $path) {
-                Remove-Item -LiteralPath $path -Force
-              }
-            }
-          }
-          foreach ($path in @(
-            (Join-Path $env:RUNNER_TEMP "usque-signing.pfx"),
-            (Join-Path $env:RUNNER_TEMP "usque-signing.cer")
-          )) {
+            $path = "Cert:\CurrentUser\My\$thumbprint"
             if (Test-Path -LiteralPath $path) {
               Remove-Item -LiteralPath $path -Force
             }
+          }
+          $pfx = Join-Path $env:RUNNER_TEMP "usque-signing.pfx"
+          if (Test-Path -LiteralPath $pfx) {
+            Remove-Item -LiteralPath $pfx -Force
           }
 
   android:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -42,10 +42,13 @@ Keep offline encrypted primary and secondary backups of both signing identities.
 All pre-1.0 packages use fixed, project-controlled self-signed identities. Any
 v1.0.0 signing transition is a separate reviewed change and must preserve the
 documented update-compatibility guarantees.
-The Windows workflow imports the certificate only into the current runner user,
-trusts it only for the job, and removes it in an `always()` cleanup step. It
-never re-signs the official Wintun DLL. The Android workflow deletes its
-temporary keystore in the same way.
+The Windows workflow imports the private signing identity only into the current
+runner user's personal certificate store. It does not add the self-signed
+certificate to Root or TrustedPublisher; verification accepts the pinned
+untrusted-root result and independently checks the DER SHA-256 fingerprint. An
+`always()` cleanup step removes the private identity. The workflow never
+re-signs the official Wintun DLL. The Android workflow deletes its temporary
+keystore in the same way.
 
 Android builds verify the Gradle 9.5.1 distribution against its published
 SHA-256, use the checked-in strict `app/gradle.lockfile`, and verify resolved

--- a/tool/verify_windows_authenticode.ps1
+++ b/tool/verify_windows_authenticode.ps1
@@ -43,9 +43,9 @@ if ($null -eq $signature.SignerCertificate) {
 
 $valid = $signature.Status -eq [System.Management.Automation.SignatureStatus]::Valid
 $pinnedSelfSigned =
-    $AllowPinnedUntrustedRoot -and
-    $signature.Status -eq [System.Management.Automation.SignatureStatus]::UnknownError -and
-    $signature.SignerCertificate.Subject -eq $signature.SignerCertificate.Issuer
+$AllowPinnedUntrustedRoot -and
+$signature.Status -eq [System.Management.Automation.SignatureStatus]::UnknownError -and
+$signature.SignerCertificate.Subject -eq $signature.SignerCertificate.Issuer
 if (-not $valid -and -not $pinnedSelfSigned) {
     throw "Authenticode verification failed for $resolvedPath ($($signature.Status))."
 }

--- a/tool/verify_windows_authenticode.ps1
+++ b/tool/verify_windows_authenticode.ps1
@@ -1,0 +1,59 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^[0-9A-Fa-f]{64}$")]
+    [string]$SignerSha256,
+
+    [switch]$AllowPinnedUntrustedRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-CertificateSha256 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [Security.Cryptography.X509Certificates.X509Certificate2]$Certificate
+    )
+
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        return (
+            $sha.ComputeHash($Certificate.GetRawCertData()) |
+                ForEach-Object { $_.ToString("X2") }
+        ) -join ""
+    } finally {
+        $sha.Dispose()
+    }
+}
+
+$resolvedPath = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
+    throw "Authenticode target is not a file: $resolvedPath"
+}
+
+$signature = Get-AuthenticodeSignature -LiteralPath $resolvedPath
+if ($null -eq $signature.SignerCertificate) {
+    throw "No signer certificate was returned for $resolvedPath."
+}
+
+$valid = $signature.Status -eq [System.Management.Automation.SignatureStatus]::Valid
+$pinnedSelfSigned =
+    $AllowPinnedUntrustedRoot -and
+    $signature.Status -eq [System.Management.Automation.SignatureStatus]::UnknownError -and
+    $signature.SignerCertificate.Subject -eq $signature.SignerCertificate.Issuer
+if (-not $valid -and -not $pinnedSelfSigned) {
+    throw "Authenticode verification failed for $resolvedPath ($($signature.Status))."
+}
+
+$expectedSigner = $SignerSha256.ToUpperInvariant()
+$actualSigner = Get-CertificateSha256 -Certificate $signature.SignerCertificate
+if (-not [StringComparer]::OrdinalIgnoreCase.Equals($actualSigner, $expectedSigner)) {
+    throw "Unexpected signer for $resolvedPath. Expected $expectedSigner, got $actualSigner."
+}
+
+Write-Output $resolvedPath


### PR DESCRIPTION
## Summary

- stop importing the pre-1.0 self-signed Windows certificate into runner Root/TrustedPublisher stores
- verify every signed project binary and MSI against Authenticode integrity plus the pinned DER SHA-256 signer identity
- document that the protected release runner keeps only the temporary private identity in its personal store

## Cause

The corrected signer fingerprint let the release jobs advance past identity matching, where both Windows architectures then blocked while importing the self-signed certificate into the runner trust stores. The cancelled attempt confirmed the cleanup step still ran.

## Validation

- actionlint .github/workflows/release.yml
- repository policy
- 21 Python release/policy tests
- PowerShell parser
- unsigned file rejection
- valid Authenticode and mismatched signer rejection
- pinned self-signed untrusted-root allow/deny policy