### PR TITLE
fix(windows): support stable MSI release versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,6 +438,29 @@ jobs:
           dotnet tool restore
           dotnet tool run wix -- extension add WixToolset.UI.wixext/5.0.2
 
+      - name: Verify MSI version mapping
+        shell: pwsh
+        run: |
+          $stable = & ./tool/convert_to_msi_version.ps1 -SemVer "v0.1.2"
+          if ($stable -ne "0.1.299") {
+            throw "Stable MSI version mapping is invalid: $stable"
+          }
+
+          $beta = & ./tool/convert_to_msi_version.ps1 -SemVer "0.1.2-beta.3"
+          if ($beta -ne "0.1.203") {
+            throw "Beta MSI version mapping is invalid: $beta"
+          }
+
+          $rejected = $false
+          try {
+            & ./tool/convert_to_msi_version.ps1 -SemVer "0.1.2-beta.0"
+          } catch {
+            $rejected = $_.Exception.Message -like "Beta ordinal must be*"
+          }
+          if (-not $rejected) {
+            throw "Invalid beta ordinal was not rejected."
+          }
+
       - name: Create inert authoring fixture
         shell: pwsh
         run: |

--- a/tool/build_windows_msi.ps1
+++ b/tool/build_windows_msi.ps1
@@ -39,33 +39,6 @@ function Resolve-ExistingDirectory {
     return $resolved.Path
 }
 
-function ConvertTo-MsiVersion {
-    param([Parameter(Mandatory = $true)][string]$SemVer)
-
-    if ($SemVer -notmatch '^v?(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)(?:-beta\.(?<beta>[0-9]+))?$') {
-        throw "Unsupported release version: $SemVer"
-    }
-
-    $major = [int]$Matches.major
-    $minor = [int]$Matches.minor
-    $patch = [int]$Matches.patch
-    $ordinal = if ($Matches.beta) { [int]$Matches.beta } else { 99 }
-
-    if ($major -gt 255 -or $minor -gt 255) {
-        throw "MSI major and minor versions must be at most 255."
-    }
-    if ($ordinal -lt 1 -or $ordinal -gt 99) {
-        throw "Beta ordinal must be between 1 and 99."
-    }
-
-    $build = ([long]$patch * 100) + $ordinal
-    if ($build -gt 65535) {
-        throw "Mapped MSI build version exceeds 65535."
-    }
-
-    return "$major.$minor.$build"
-}
-
 function Get-CertificateSha256 {
     param(
         [Parameter(Mandatory = $true)]
@@ -225,7 +198,8 @@ if (-not (Test-Path -LiteralPath $iconPath -PathType Leaf)) {
 New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
 $outputRoot = (Resolve-Path -LiteralPath $OutputDirectory).Path
 $displayVersion = $Version.TrimStart("v")
-$msiVersion = ConvertTo-MsiVersion -SemVer $Version
+$msiVersion = & (Join-Path $PSScriptRoot "convert_to_msi_version.ps1") `
+    -SemVer $Version
 $outputPath = Join-Path $outputRoot "usque-v$displayVersion-windows-$Variant.msi"
 $intermediatePath = Join-Path $outputRoot "wix-$Variant"
 New-Item -ItemType Directory -Path $intermediatePath -Force | Out-Null

--- a/tool/convert_to_msi_version.ps1
+++ b/tool/convert_to_msi_version.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern("^v?[0-9]+\.[0-9]+\.[0-9]+(?:-beta\.[0-9]+)?$")]
+    [string]$SemVer
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($SemVer -notmatch '^v?(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)(?:-beta\.(?<beta>[0-9]+))?$') {
+    throw "Unsupported release version: $SemVer"
+}
+
+$major = [int]$Matches.major
+$minor = [int]$Matches.minor
+$patch = [int]$Matches.patch
+$ordinal = if ($Matches.ContainsKey("beta")) {
+    [int]$Matches.beta
+} else {
+    99
+}
+
+if ($major -gt 255 -or $minor -gt 255) {
+    throw "MSI major and minor versions must be at most 255."
+}
+if ($ordinal -lt 1 -or $ordinal -gt 99) {
+    throw "Beta ordinal must be between 1 and 99."
+}
+
+$build = ([long]$patch * 100) + $ordinal
+if ($build -gt 65535) {
+    throw "Mapped MSI build version exceeds 65535."
+}
+
+Write-Output "$major.$minor.$build"


### PR DESCRIPTION
## Summary

- move MSI SemVer mapping into a directly testable PowerShell helper
- avoid StrictMode access to a missing beta regex group for stable releases
- assert stable, beta, and invalid-beta mappings in both Windows MSI authoring CI variants

## Release evidence

The v0.1.2 release run proved PFX import and signed-binary verification now pass on both Windows architectures. Both then failed before WiX invocation because v0.1.2 has no beta capture and the old converter read $Matches.beta under StrictMode.

## Validation

- v0.1.2 maps to 0.1.299
- 0.1.2-beta.3 maps to 0.1.203
- invalid beta and MSI bounds fail closed
- PSScriptAnalyzer 1.25.0 clean
- actionlint and repository policy
- 21 release/policy tests