### PR TITLE
fix(release): publish only install packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -561,7 +561,7 @@ jobs:
           fi
 
   stage-candidate:
-    name: Build checksums, SBOMs, and license inventories
+    name: Stage signed packages and attest SBOMs
     needs: [release-gate, windows, android]
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -592,7 +592,7 @@ jobs:
         with:
           syft-version: v1.44.0
 
-      - name: Generate per-artifact SPDX, CycloneDX, and license lists
+      - name: Generate per-artifact SPDX for GitHub attestations
         shell: bash
         env:
           SYFT: ${{ steps.syft.outputs.cmd }}
@@ -610,23 +610,8 @@ jobs:
             cp third_party/wintun-0.14.1/wintun/LICENSE.txt \
               "$context/WINTUN-LICENSE.txt"
             "$SYFT" scan "dir:$context" \
-              -o "spdx-json=$artifact.spdx.json" \
-              -o "cyclonedx-json=$artifact.cdx.json"
-            {
-              printf 'name\tversion\tlicense_declared\tlicense_concluded\n'
-              jq -r '
-                .packages[]? |
-                [
-                  (.name // "UNKNOWN"),
-                  (.versionInfo // "UNKNOWN"),
-                  (.licenseDeclared // "NOASSERTION"),
-                  (.licenseConcluded // "NOASSERTION")
-                ] | @tsv
-              ' "$artifact.spdx.json"
-            } > "$artifact.licenses.tsv"
+              -o "spdx-json=$artifact.spdx.json"
             test -s "$artifact.spdx.json"
-            test -s "$artifact.cdx.json"
-            test -s "$artifact.licenses.tsv"
             rm -rf -- "$context"
             count=$((count + 1))
           done < <(
@@ -637,7 +622,7 @@ jobs:
           )
           test "$count" -eq 6
 
-      - name: Create immutable release manifest and SHA-256 sidecars
+      - name: Create immutable release manifest
         run: |
           python tool/release_contract.py create-manifest \
             --directory "$RUNNER_TEMP/candidate" \
@@ -719,6 +704,17 @@ jobs:
           python tool/release_contract.py verify-artifacts \
             --directory "$RUNNER_TEMP/candidate" \
             --manifest "$RUNNER_TEMP/candidate/release-manifest.json"
+          publish="$RUNNER_TEMP/publish"
+          mkdir -p "$publish"
+          while IFS= read -r -d '' artifact; do
+            cp -- "$artifact" "$publish/"
+          done < <(
+            find "$RUNNER_TEMP/candidate" -maxdepth 1 -type f \
+              \( -name '*.msi' -o -name '*.apk' \) \
+              -print0 |
+              sort -z
+          )
+          test "$(find "$publish" -maxdepth 1 -type f | wc -l)" -eq 6
 
       - name: Publish GitHub release only after signing and supply-chain gates
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -727,4 +723,4 @@ jobs:
           draft: false
           fail_on_unmatched_files: true
           generate_release_notes: true
-          files: ${{ runner.temp }}/candidate/**
+          files: ${{ runner.temp }}/publish/*

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 Usque is an unofficial GUI client for consumer Cloudflare WARP. Flutter draws the UI. A Rust engine handles MASQUE, CONNECT-IP, DNS, proxies, and connection state. There is no WebView.
 
 > [!IMPORTANT]
-> The current release is **v0.1.3**. Only files attached to the [`v0.1.3` GitHub Release](https://github.com/GeorgeXie2333/usque-app/releases/tag/v0.1.3), with matching checksums and signer fingerprints, are official. Pull Request artifacts, local builds, and untagged binaries are not.
+> The current release is **v0.1.3**. Download official packages only from the [GitHub Releases page](https://github.com/GeorgeXie2333/usque-app/releases). Pull Request artifacts, local builds, and untagged binaries are not official.
 
 Usque is an independent project. It is not affiliated with, sponsored by, or endorsed by Cloudflare. Cloudflare and WARP are trademarks of Cloudflare, Inc. Use of consumer WARP remains subject to Cloudflare's terms and privacy policy.
 
@@ -75,23 +75,12 @@ These values can be changed and reset. A non-loopback proxy listener has no pass
 
 ## Availability and installation
 
-Download `v0.1.3` only from the [official release page](https://github.com/GeorgeXie2333/usque-app/releases/tag/v0.1.3):
-
-| Target | File |
-| --- | --- |
-| Windows x64 | [`usque-v0.1.3-windows-x64-v2.msi`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-windows-x64-v2.msi) |
-| Windows ARM64 | [`usque-v0.1.3-windows-arm64.msi`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-windows-arm64.msi) |
-| Android ARMv8 | [`usque-v0.1.3-android-arm64-v8a.apk`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-android-arm64-v8a.apk) |
-| Android x64 | [`usque-v0.1.3-android-x86_64.apk`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-android-x86_64.apk) |
-| Android ARMv7 | [`usque-v0.1.3-android-armeabi-v7a.apk`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-android-armeabi-v7a.apk) |
-| Android universal | [`usque-v0.1.3-android-universal.apk`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-android-universal.apk) |
-
-Prefer the APK that matches the device ABI. The universal APK includes ARMv8, x64, and ARMv7 libraries and is larger; use it when the architecture is unknown. The release also has `SHA256SUMS`, a `.sha256` file per package, SPDX/CycloneDX SBOMs, license inventories, and build attestations.
+Download Usque from the [GitHub Releases page](https://github.com/GeorgeXie2333/usque-app/releases). Prefer the APK that matches the device ABI. The universal APK includes ARMv8, x64, and ARMv7 libraries and is larger; use it when the architecture is unknown. GitHub shows a SHA-256 for each asset; compare that digest and the published signer fingerprint before installing.
 
 - Pre-1.0 Windows packages use a fixed self-signed identity. Check the published SHA-256 and certificate fingerprint before accepting the OS warning.
 - Pre-1.0 Android packages use a project-controlled self-signed certificate and are not on Google Play. You may need a manual install or ADB.
 - A later v1.0.0 signing change will be its own release.
-- The release workflow compiles, signs, and checks architecture, checksums, SBOMs, and provenance. It does not install packages on real devices or run long VPN tests.
+- The release workflow compiles, signs, and checks architecture, checksums, SBOMs, and provenance. It does not attach those extras to the GitHub Release, and it does not install packages on real devices or run long VPN tests.
 - Usque never installs updates by itself. Optional update checks only open the release page.
 - Windows uninstall asks for confirmation in Settings, restores Usque-owned network state, and can delete the current user's local data if you ask.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@
 Usque 是面向 Cloudflare WARP 个人版（Consumer WARP）的非官方图形客户端。界面由 Flutter 实现；MASQUE、CONNECT-IP、DNS、代理与连接状态由 Rust 引擎处理。项目不使用 WebView。
 
 > [!IMPORTANT]
-> 当前发布版本为 **v0.1.3**。仅 [`v0.1.3` GitHub Release](https://github.com/GeorgeXie2333/usque-app/releases/tag/v0.1.3) 所附文件，且校验和与签名者指纹一致时，视为正式发布包。Pull Request 构建、本地构建以及未打标签的二进制均非正式发布。
+> 当前发布版本为 **v0.1.3**。请仅从 [GitHub Releases 页面](https://github.com/GeorgeXie2333/usque-app/releases) 下载正式安装包。Pull Request 构建、本地构建以及未打标签的二进制均非正式发布。
 
 Usque 为独立项目，与 Cloudflare 无隶属、赞助或背书关系。Cloudflare 与 WARP 是 Cloudflare, Inc. 的商标。使用个人版 WARP 仍须遵守 Cloudflare 的适用条款与隐私政策。
 
@@ -75,23 +75,12 @@ Usque 为独立项目，与 Cloudflare 无隶属、赞助或背书关系。Cloud
 
 ## 获取与安装
 
-请仅从[正式发布页面](https://github.com/GeorgeXie2333/usque-app/releases/tag/v0.1.3)下载 `v0.1.3`：
-
-| 目标 | 文件 |
-| --- | --- |
-| Windows x64 | [`usque-v0.1.3-windows-x64-v2.msi`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-windows-x64-v2.msi) |
-| Windows ARM64 | [`usque-v0.1.3-windows-arm64.msi`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-windows-arm64.msi) |
-| Android ARMv8 | [`usque-v0.1.3-android-arm64-v8a.apk`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-android-arm64-v8a.apk) |
-| Android x64 | [`usque-v0.1.3-android-x86_64.apk`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-android-x86_64.apk) |
-| Android ARMv7 | [`usque-v0.1.3-android-armeabi-v7a.apk`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-android-armeabi-v7a.apk) |
-| Android 通用包 | [`usque-v0.1.3-android-universal.apk`](https://github.com/GeorgeXie2333/usque-app/releases/download/v0.1.3/usque-v0.1.3-android-universal.apk) |
-
-请优先选择与设备 ABI 匹配的 APK。通用安装包同时包含 ARMv8、x64 与 ARMv7 原生库，体积更大，仅建议在无法确定设备架构时使用。发布页同时提供 `SHA256SUMS`、各安装包对应的 `.sha256` 文件、SPDX/CycloneDX SBOM、许可证清单与构建证明。
+请从 [GitHub Releases 页面](https://github.com/GeorgeXie2333/usque-app/releases) 下载 Usque。请优先选择与设备 ABI 匹配的 APK。通用安装包同时包含 ARMv8、x64 与 ARMv7 原生库，体积更大，仅建议在无法确定设备架构时使用。GitHub 会为每个资源显示 SHA-256；安装前请核对摘要与已公布的签名者指纹。
 
 - 1.0 之前的 Windows 安装包使用固定自签名身份。接受系统警告前，请核对已公布的 SHA-256 与证书指纹。
 - 1.0 之前的 Android 安装包使用项目自行管理的固定自签名证书，不通过 Google Play 分发，可能需要手动安装或使用 ADB。
 - v1.0.0 的签名变更将作为独立版本发布。
-- 发布流程会完成编译、签名，以及架构、校验和、SBOM 与构建来源检查，但不会在真机上安装软件包，也不会进行长时间 VPN 验证。
+- 发布流程会完成编译、签名，以及架构、校验和、SBOM 与构建来源检查，但不会把这些附属文件挂到 GitHub Release 上，也不会在真机上安装软件包，也不会进行长时间 VPN 验证。
 - Usque 不会自动安装更新；可选的更新检查仅打开发布页面。
 - Windows 卸载会在系统设置中要求确认，随后恢复 Usque 修改过的网络状态；用户可选择删除当前用户的本地数据。
 

--- a/docs/CODE_SIGNING.md
+++ b/docs/CODE_SIGNING.md
@@ -39,8 +39,8 @@ Only the release maintainer may approve `release-signing` and `release-publish`.
 
 Before installing:
 
-1. Download the package and its `.sha256` file from the same GitHub Release.
-2. Compare the full package SHA-256.
+1. Download the package from the [GitHub Releases page](https://github.com/GeorgeXie2333/usque-app/releases).
+2. Compare the full package SHA-256 with the digest GitHub shows for that asset.
 3. Compare the signer fingerprint with the value in that release's notes.
 4. Check the GitHub artifact attestation when it is available.
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -160,7 +160,7 @@ Desktop UI and engine remain unprivileged. The desktop agent accepts only versio
 - [ ] Throughput, latency, and memory versus the Go oracle (wish targets: throughput >= 90%, p95 latency regression <= 10%, memory <= 125%). These are not v0.1.3 release gates, and the pipeline does not measure them yet.
 - [x] Stable signing identities and published fingerprints.
 - [x] All declared packages built from the `v0.1.3` tag on `main`.
-- [x] SHA-256, SPDX/CycloneDX SBOM, provenance, commit, certificate fingerprint, and license inventory.
+- [x] SHA-256, SPDX SBOM attestations, provenance, commit, and certificate fingerprint.
 - [ ] Clean-machine installation and removal validation for every artifact.
 
 The release workflow fails if a Windows or Android artifact, signing input, architecture check, required CI result, manifest, SBOM, or attestation is missing. A local binary cannot replace a failed GitHub Actions artifact. Real-device, leak, performance, and clean-machine items above are still open hardening work.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation and removal
 
-Install only packages from this repository's GitHub release for `v0.1.3`.
+Install only packages from this repository's [GitHub Releases page](https://github.com/GeorgeXie2333/usque-app/releases) for `v0.1.3`.
 
 ## Official packages
 
@@ -11,12 +11,12 @@ Install only packages from this repository's GitHub release for `v0.1.3`.
 - `usque-v0.1.3-android-armeabi-v7a.apk`
 - `usque-v0.1.3-android-universal.apk`
 
-Each release also has SHA-256 sidecars, signer fingerprints, SPDX and CycloneDX SBOMs, dependency license inventories, and GitHub build provenance. A local validation package, Actions development output, fork artifact, or a file from somewhere else is not an official release. Official identities and fingerprint rules are in [CODE_SIGNING.md](CODE_SIGNING.md).
+The GitHub Release attaches only those six packages. GitHub shows a SHA-256 for each asset. Signer fingerprints, SBOMs, and build provenance stay in the release notes and GitHub attestations. A local validation package, Actions development output, fork artifact, or a file from somewhere else is not an official release. Official identities and fingerprint rules are in [CODE_SIGNING.md](CODE_SIGNING.md).
 
 ## Verify before installing
 
-1. Download the package and its `.sha256` file from the same GitHub release.
-2. Calculate the package SHA-256 and compare the full 64-character value.
+1. Download the package from the [GitHub Releases page](https://github.com/GeorgeXie2333/usque-app/releases).
+2. Calculate the package SHA-256 and compare it with the digest GitHub shows for that asset.
 3. Compare the package signer with the fingerprint in the release notes.
 4. Check the GitHub artifact attestation when it is available.
 5. Stop if the filename, hash, signature, architecture, or version differs.
@@ -77,6 +77,6 @@ Uninstalling the app removes its Android Keystore entries and private data the w
 
 Usque never downloads or installs an update by itself. At most once every 24 hours it can check this repository for a newer release, show a notification, and open the release page. Automatic checks can be turned off; a manual check stays available.
 
-Treat each update as a new package: check the filename, hash, signer, architecture, manifest, and attestations before installing.
+Treat each update as a new package: check the filename, GitHub SHA-256, signer, architecture, and attestations before installing.
 
 The GitHub release workflow does not install packages on physical devices or run long VPN tests. Signing and supply-chain steps are in [RELEASE.md](RELEASE.md).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -43,9 +43,9 @@ The MSI does not install the publisher certificate into the machine Root or Trus
 
 1. The tag job builds signed x64-v2 and ARM64 MSIs plus signed arm64-v8a, x86_64, armeabi-v7a, and universal APKs in the signing environment.
 2. Each platform job checks the certificate identity and creates GitHub build provenance.
-3. A staging job downloads those artifacts, rejects missing or extra MSI/APK files, and writes SHA-256 sidecars, SPDX and CycloneDX SBOMs, license inventories, and SBOM attestations.
+3. A staging job downloads those artifacts, rejects missing or extra MSI/APK files, writes an internal release manifest, generates SPDX SBOMs, and records SBOM attestations.
 4. The publish job downloads the staged candidate and checks every primary file against the immutable manifest.
-5. Only then does the workflow create the GitHub release.
+5. Only then does the workflow create the GitHub release, attaching the six install packages and nothing else.
 
 Primary files:
 

--- a/tool/release_contract.py
+++ b/tool/release_contract.py
@@ -105,7 +105,6 @@ def create_manifest(
         )
 
     artifacts = []
-    checksum_lines = []
     for name in sorted(expected):
         path = directory / name
         digest = sha256_file(path)
@@ -119,11 +118,6 @@ def create_manifest(
                 "size": path.stat().st_size,
             }
         )
-        checksum_line = f"{digest} *{name}\n"
-        (directory / f"{name}.sha256").write_text(checksum_line, encoding="utf-8")
-        checksum_lines.append(checksum_line)
-
-    (directory / "SHA256SUMS").write_text("".join(checksum_lines), encoding="utf-8")
     return {
         "schema_version": SCHEMA_VERSION,
         "tag": tag,

--- a/tool/test_release_contract.py
+++ b/tool/test_release_contract.py
@@ -26,6 +26,9 @@ class ReleaseContractTests(unittest.TestCase):
         index = release_contract.artifact_index(manifest)
         self.assertEqual(6, len(index))
         release_contract.verify_artifacts(self.root, manifest)
+        self.assertFalse((self.root / "SHA256SUMS").exists())
+        for name in index:
+            self.assertFalse((self.root / f"{name}.sha256").exists())
 
     def test_manifest_rejects_an_unexpected_primary_artifact(self) -> None:
         (self.root / "unexpected.apk").write_bytes(b"no")


### PR DESCRIPTION
﻿## Summary
- GitHub Releases now attach only the six install packages (2 MSI + 4 APK). SHA-256 sidecars, `SHA256SUMS`, CycloneDX, SPDX files, license TSVs, and the internal manifest stay off the release page.
- Staging still hashes packages, writes an internal manifest, and records SPDX attestations. Users verify with the SHA-256 GitHub already shows on each asset.
- README (EN/ZH) points to https://github.com/GeorgeXie2333/usque-app/releases instead of per-file download links.

## Test plan
- [ ] `python -m unittest discover -s tool -p "test_release_contract.py" -v`
- [ ] Required PR gates green
- [ ] After merge, the next tagged release (not this PR) publishes only `.msi` and `.apk`

This PR does not tag or publish a release.
