### PR TITLE
fix: ship v0.2.3 major MASQUE stability fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,7 +24,7 @@ body:
     attributes:
       label: Version or commit
       description: Use the exact release tag, validation label, or commit SHA.
-      placeholder: v0.2.2 or 40-character commit SHA
+      placeholder: v0.2.3 or 40-character commit SHA
     validations:
       required: true
   - type: dropdown

--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -6,14 +6,14 @@ immediately below the matching English text.
 
 ## Highlights / 更新亮点
 
-- Verified in-app upgrades are now available on Windows and Android. Usque requires the architecture-matched package, release manifest, size, SHA-256, signer, package identity, and version to agree before handing the update to the platform installer.
-  <br>Windows 与 Android 现已支持经过验证的应用内升级。Usque 仅在架构匹配的软件包、Release 清单、大小、SHA-256、签名者、软件包身份和版本全部一致后，才会将更新交给系统安装程序。
-- Structured diagnostics now explain tunnel, transport, frontend, and platform failures and can export privacy-sanitized evidence. Official releases add an immutable manifest, checksums, and per-package SBOMs; isolated-runner reports remain optional supplemental validation.
-  <br>结构化诊断现可说明隧道、传输层、前端和平台故障，并导出经过隐私清理的证据。正式 Release 还会附带不可变清单、校验和与逐包 SBOM；隔离 Runner 报告作为可选的补充验证。
-- H3 and H2 transport paths now reduce packet copies, allocations, logging contention, and nested timers. Windows packet-ring batching and fairer Android tunnel scheduling improve sustained traffic handling.
-  <br>H3 与 H2 传输路径现已减少数据包复制、内存分配、日志竞争和嵌套计时器；Windows 数据包环批处理与更公平的 Android 隧道调度可改善持续流量处理。
-- Navigation, accessibility, touch behavior, platform-specific VPN labels, and translations have been refined. Zero Trust reauthentication now preserves registration-owned endpoint addresses while sharing device-wide port and SNI settings consistently.
-  <br>导航、无障碍、触控行为、平台专用 VPN 标签和翻译均已改进；Zero Trust 重新认证现会保留注册方下发的端点地址，并一致共享设备级端口与 SNI 设置。
+- Usque v0.2.3 is a major bug-fix release focused on eliminating traffic stalls and premature packet loss when sustained traffic fills MASQUE or platform packet queues.
+  <br>Usque v0.2.3 是一个重大 Bug 修复版本，重点解决持续流量填满 MASQUE 或平台数据包队列时出现的流量停滞和过早丢包问题。
+- H3 and H2 now retain bounded packet batches and apply backpressure until capacity returns instead of dropping or failing sends while the transport is still healthy. Closing or cancelling a path also releases blocked senders cleanly.
+  <br>H3 与 H2 现在会保留有界数据包批次，并持续施加背压直至容量恢复，而不会在传输仍然健康时丢弃数据包或令发送失败；关闭或取消路径时也会干净地释放被阻塞的发送方。
+- Windows packet-ring publication and Android tunnel scheduling now process bounded, ordered batches and resume in order after congestion, improving sustained traffic handling without introducing unbounded work.
+  <br>Windows 数据包环发布和 Android 隧道调度现在会处理有界、有序的批次，并在拥塞后按顺序恢复，从而改善持续流量处理且不会引入无界工作量。
+- Drop accounting and transport telemetry now distinguish real bounded-queue overflow from recoverable queue pressure. Pinned Rust dependencies and CI, CodeQL, Java, and SBOM tooling have also been refreshed.
+  <br>丢包计数与传输遥测现在能够区分真实的有界队列溢出和可恢复的队列压力；固定的 Rust 依赖以及 CI、CodeQL、Java 与 SBOM 工具也已更新。
 
 ### DNS privacy / DNS 隐私
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install Java for Android SDK tooling
         if: matrix.variant == 'x64-v2'
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "17"
@@ -207,7 +207,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "17"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,12 +401,12 @@ jobs:
       - name: Test fail-closed artifact contract
         run: python -m unittest discover -s tool -p "test_*.py" -v
 
-      - name: Verify v0.2.2 release version contract
+      - name: Verify v0.2.3 release version contract
         run: |
           python tool/release_contract.py verify-version \
             --root . \
-            --tag v0.2.2 \
-            --android-version-code 16
+            --tag v0.2.3 \
+            --android-version-code 17
 
   windows-installer-authoring:
     name: MSI authoring (${{ matrix.arch }})
@@ -442,19 +442,19 @@ jobs:
       - name: Verify MSI version mapping
         shell: pwsh
         run: |
-          $stable = & ./tool/convert_to_msi_version.ps1 -SemVer "v0.2.2"
-          if ($stable -ne "0.2.299") {
+          $stable = & ./tool/convert_to_msi_version.ps1 -SemVer "v0.2.3"
+          if ($stable -ne "0.2.399") {
             throw "Stable MSI version mapping is invalid: $stable"
           }
 
-          $beta = & ./tool/convert_to_msi_version.ps1 -SemVer "0.2.2-beta.3"
-          if ($beta -ne "0.2.203") {
+          $beta = & ./tool/convert_to_msi_version.ps1 -SemVer "0.2.3-beta.3"
+          if ($beta -ne "0.2.303") {
             throw "Beta MSI version mapping is invalid: $beta"
           }
 
           $rejected = $false
           try {
-            & ./tool/convert_to_msi_version.ps1 -SemVer "0.2.2-beta.0"
+            & ./tool/convert_to_msi_version.ps1 -SemVer "0.2.3-beta.0"
           } catch {
             $rejected = $_.Exception.Message -like "Beta ordinal must be*"
           }
@@ -485,8 +485,8 @@ jobs:
             -arch "${{ matrix.arch }}" `
             -ext "WixToolset.UI.wixext/5.0.2" `
             -bindpath "app=$payload" `
-            -define "DisplayVersion=0.2.2" `
-            -define "MsiVersion=0.2.299" `
+            -define "DisplayVersion=0.2.3" `
+            -define "MsiVersion=0.2.399" `
             -define "Variant=${{ matrix.variant }}" `
             -define "SignerSha256=$("0" * 64)" `
             -define "IconPath=$((Resolve-Path "assets/branding/usque-app-icon.ico").Path)" `
@@ -502,8 +502,8 @@ jobs:
           & ./tool/verify_windows_msi.ps1 `
             -MsiPath $output `
             -Variant "${{ matrix.variant }}" `
-            -ExpectedMsiVersion "0.2.299" `
-            -ExpectedDisplayVersion "0.2.2" `
+            -ExpectedMsiVersion "0.2.399" `
+            -ExpectedDisplayVersion "0.2.3" `
             -SignerSha256 ("0" * 64)
 
           # Equal-version validation packages intentionally replace the same

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "17"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,13 +41,13 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           build-mode: none
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Public release
 on:
   push:
     tags:
-      - "v0.2.2"
+      - "v0.2.3"
 
 concurrency:
   group: release-${{ github.ref }}
@@ -17,8 +17,8 @@ env:
   CMAKE_GENERATOR: Ninja
   FLUTTER_COMMIT: 84fc5cbb223bc12f83d65b647ff8a56caf779ffd
   FLUTTER_VERSION: 3.44.7
-  RELEASE_TAG: v0.2.2
-  ANDROID_VERSION_CODE: "16"
+  RELEASE_TAG: v0.2.3
+  ANDROID_VERSION_CODE: "17"
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,7 +381,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "17"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -594,7 +594,7 @@ jobs:
 
       - name: Install pinned Syft
         id: syft
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        uses: anchore/sbom-action/download-syft@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
           syft-version: v1.44.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1781,7 +1781,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2370,7 +2370,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2909,9 +2909,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3087,7 +3087,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "usque-agent"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "usque-android"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "ipnet",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "usque-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "usque-engine"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "usque-geo"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "futures",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "usque-ipc"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "prost",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "usque-platform"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "security-framework",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "usque-protocol"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "proptest",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "usque-transport"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "boring",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "usque-uninstall"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "thiserror",
  "windows-sys 0.61.2",
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "usque-update"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 rust-version = "1.97.1"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 Usque is an unofficial GUI client for consumer Cloudflare WARP. Flutter draws the UI. A Rust engine handles MASQUE, CONNECT-IP, DNS, proxies, and connection state. There is no WebView.
 
 > [!IMPORTANT]
-> The current release is **v0.2.2**. Download official packages only from the [GitHub Releases page](https://github.com/GeorgeXie2333/usque-app/releases). Pull Request artifacts, local builds, and untagged binaries are not official.
+> The current release is **v0.2.3**. Download official packages only from the [GitHub Releases page](https://github.com/GeorgeXie2333/usque-app/releases). Pull Request artifacts, local builds, and untagged binaries are not official.
 
 Usque is an independent project. It is not affiliated with, sponsored by, or endorsed by Cloudflare. Cloudflare and WARP are trademarks of Cloudflare, Inc. Use of consumer WARP remains subject to Cloudflare's terms and privacy policy.
 
@@ -43,7 +43,7 @@ Usque is an independent project. It is not affiliated with, sponsored by, or end
 
 ## Release targets
 
-The `v0.2.2` tag on `main` builds and checks these six packages:
+The `v0.2.3` tag on `main` builds and checks these six packages:
 
 | Platform | Package | Minimum OS | Architecture |
 | --- | --- | --- | --- |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@
 Usque 是面向 Cloudflare WARP 个人版（Consumer WARP）的非官方图形客户端。界面由 Flutter 实现；MASQUE、CONNECT-IP、DNS、代理与连接状态由 Rust 引擎处理。项目不使用 WebView。
 
 > [!IMPORTANT]
-> 当前发布版本为 **v0.2.2**。请仅从 [GitHub Releases 页面](https://github.com/GeorgeXie2333/usque-app/releases) 下载正式安装包。Pull Request 构建、本地构建以及未打标签的二进制均非正式发布。
+> 当前发布版本为 **v0.2.3**。请仅从 [GitHub Releases 页面](https://github.com/GeorgeXie2333/usque-app/releases) 下载正式安装包。Pull Request 构建、本地构建以及未打标签的二进制均非正式发布。
 
 Usque 为独立项目，与 Cloudflare 无隶属、赞助或背书关系。Cloudflare 与 WARP 是 Cloudflare, Inc. 的商标。使用个人版 WARP 仍须遵守 Cloudflare 的适用条款与隐私政策。
 
@@ -43,7 +43,7 @@ Usque 为独立项目，与 Cloudflare 无隶属、赞助或背书关系。Cloud
 
 ## 发布范围
 
-`v0.2.2` 由 `main` 上的对应标签构建并校验以下六个安装包：
+`v0.2.3` 由 `main` 上的对应标签构建并校验以下六个安装包：
 
 | 平台 | 安装包 | 最低系统 | 架构 |
 | --- | --- | --- | --- |

--- a/apps/usque_gui/android/app/src/test/kotlin/io/github/georgexie2333/usque/AndroidUpdateInstallerTest.kt
+++ b/apps/usque_gui/android/app/src/test/kotlin/io/github/georgexie2333/usque/AndroidUpdateInstallerTest.kt
@@ -28,11 +28,11 @@ class AndroidUpdateInstallerTest {
         val request =
             AndroidUpdateInstaller.fromArguments(
                 mapOf(
-                    "path" to "/private/cache/usque-v0.2.3-android-arm64-v8a.apk",
-                    "version" to "v0.2.3",
+                    "path" to "/private/cache/usque-v0.2.4-android-arm64-v8a.apk",
+                    "version" to "v0.2.4",
                     "package" to
                         mapOf(
-                            "name" to "usque-v0.2.3-android-arm64-v8a.apk",
+                            "name" to "usque-v0.2.4-android-arm64-v8a.apk",
                             "size" to 4_294_967_296L,
                             "sha256" to "a5".repeat(32),
                             "platform" to "android",
@@ -43,7 +43,7 @@ class AndroidUpdateInstallerTest {
 
         assertEquals(4_294_967_296L, request.size)
         assertEquals("arm64-v8a", request.variant)
-        assertEquals("v0.2.3", request.version)
+        assertEquals("v0.2.4", request.version)
     }
 
     @Test

--- a/apps/usque_gui/lib/core/l10n/ar.dart
+++ b/apps/usque_gui/lib/core/l10n/ar.dart
@@ -290,7 +290,7 @@ const Map<String, String> kArCatalog = <String, String>{
   'diagnostics_subtitle': 'حالة محرك Usque وتصدير السجلات والبيانات المحلية.',
   'engine_status': 'حالة محرك Usque',
   'version': 'الإصدار',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'السجلات المحلية',
   'export_diagnostics': 'تصدير حزمة التشخيص',
   'diagnostics_saved': 'تم حفظ حزمة التشخيص في',

--- a/apps/usque_gui/lib/core/l10n/de.dart
+++ b/apps/usque_gui/lib/core/l10n/de.dart
@@ -301,7 +301,7 @@ const Map<String, String> kDeCatalog = <String, String>{
       'Status der Usque Engine, Protokollexport und lokale Daten.',
   'engine_status': 'Status der Usque Engine',
   'version': 'Version',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Lokale Protokolle',
   'export_diagnostics': 'Diagnosepaket exportieren',
   'diagnostics_saved': 'Diagnosepaket gespeichert unter',

--- a/apps/usque_gui/lib/core/l10n/en.dart
+++ b/apps/usque_gui/lib/core/l10n/en.dart
@@ -294,7 +294,7 @@ const Map<String, String> kEnCatalog = <String, String>{
   'diagnostics_subtitle': 'Usque Engine state, log export, and local data.',
   'engine_status': 'Usque Engine status',
   'version': 'Version',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Local logs',
   'export_diagnostics': 'Export diagnostic bundle',
   'diagnostics_saved': 'Diagnostic bundle saved to',

--- a/apps/usque_gui/lib/core/l10n/es.dart
+++ b/apps/usque_gui/lib/core/l10n/es.dart
@@ -300,7 +300,7 @@ const Map<String, String> kEsCatalog = <String, String>{
       'Estado de Usque Engine, exportación de registros y datos locales.',
   'engine_status': 'Estado de Usque Engine',
   'version': 'Versión',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Registros locales',
   'export_diagnostics': 'Exportar paquete de diagnóstico',
   'diagnostics_saved': 'Paquete de diagnóstico guardado en',

--- a/apps/usque_gui/lib/core/l10n/fa.dart
+++ b/apps/usque_gui/lib/core/l10n/fa.dart
@@ -292,7 +292,7 @@ const Map<String, String> kFaCatalog = <String, String>{
   'diagnostics_subtitle': 'وضعیت موتور Usque، صادر کردن گزارش و داده‌های محلی.',
   'engine_status': 'وضعیت موتور Usque',
   'version': 'نسخه',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'گزارش‌های محلی',
   'export_diagnostics': 'صادر کردن بستهٔ عیب‌یابی',
   'diagnostics_saved': 'بستهٔ عیب‌یابی در این مسیر ذخیره شد:',

--- a/apps/usque_gui/lib/core/l10n/fr.dart
+++ b/apps/usque_gui/lib/core/l10n/fr.dart
@@ -302,7 +302,7 @@ const Map<String, String> kFrCatalog = <String, String>{
       'État de l’Usque Engine, export des journaux et données locales.',
   'engine_status': 'État de l’Usque Engine',
   'version': 'Version',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Journaux locaux',
   'export_diagnostics': 'Exporter l’archive de diagnostics',
   'diagnostics_saved': 'Archive de diagnostics enregistrée dans',

--- a/apps/usque_gui/lib/core/l10n/id.dart
+++ b/apps/usque_gui/lib/core/l10n/id.dart
@@ -293,7 +293,7 @@ const Map<String, String> kIdCatalog = <String, String>{
   'diagnostics_subtitle': 'Status Usque Engine, ekspor log, dan data lokal.',
   'engine_status': 'Status Usque Engine',
   'version': 'Versi',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Log lokal',
   'export_diagnostics': 'Ekspor bundel diagnostik',
   'diagnostics_saved': 'Bundel diagnostik disimpan ke',

--- a/apps/usque_gui/lib/core/l10n/it.dart
+++ b/apps/usque_gui/lib/core/l10n/it.dart
@@ -300,7 +300,7 @@ const Map<String, String> kItCatalog = <String, String>{
       'Stato dell’Usque Engine, esportazione dei log e dati locali.',
   'engine_status': 'Stato dell’Usque Engine',
   'version': 'Versione',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Log locali',
   'export_diagnostics': 'Esporta pacchetto diagnostico',
   'diagnostics_saved': 'Pacchetto diagnostico salvato in',

--- a/apps/usque_gui/lib/core/l10n/ja.dart
+++ b/apps/usque_gui/lib/core/l10n/ja.dart
@@ -280,7 +280,7 @@ const Map<String, String> kJaCatalog = <String, String>{
   'diagnostics_subtitle': 'Usque Engine の状態、ログのエクスポート、ローカルデータ。',
   'engine_status': 'Usque Engine の状態',
   'version': 'バージョン',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'ローカルログ',
   'export_diagnostics': '診断バンドルをエクスポート',
   'diagnostics_saved': '診断バンドルの保存先',

--- a/apps/usque_gui/lib/core/l10n/ko.dart
+++ b/apps/usque_gui/lib/core/l10n/ko.dart
@@ -281,7 +281,7 @@ const Map<String, String> kKoCatalog = <String, String>{
   'diagnostics_subtitle': 'Usque Engine 상태, 로그 내보내기, 로컬 데이터입니다.',
   'engine_status': 'Usque Engine 상태',
   'version': '버전',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': '로컬 로그',
   'export_diagnostics': '진단 번들 내보내기',
   'diagnostics_saved': '진단 번들을 저장한 위치',

--- a/apps/usque_gui/lib/core/l10n/nl.dart
+++ b/apps/usque_gui/lib/core/l10n/nl.dart
@@ -297,7 +297,7 @@ const Map<String, String> kNlCatalog = <String, String>{
       'Status van Usque Engine, export van logboeken en lokale gegevens.',
   'engine_status': 'Status van Usque Engine',
   'version': 'Versie',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Lokale logboeken',
   'export_diagnostics': 'Diagnostisch pakket exporteren',
   'diagnostics_saved': 'Diagnostisch pakket opgeslagen in',

--- a/apps/usque_gui/lib/core/l10n/pl.dart
+++ b/apps/usque_gui/lib/core/l10n/pl.dart
@@ -298,7 +298,7 @@ const Map<String, String> kPlCatalog = <String, String>{
       'Stan Usque Engine, eksport dzienników i dane lokalne.',
   'engine_status': 'Stan Usque Engine',
   'version': 'Wersja',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Dzienniki lokalne',
   'export_diagnostics': 'Eksportuj pakiet diagnostyczny',
   'diagnostics_saved': 'Pakiet diagnostyczny zapisano w',

--- a/apps/usque_gui/lib/core/l10n/pt.dart
+++ b/apps/usque_gui/lib/core/l10n/pt.dart
@@ -298,7 +298,7 @@ const Map<String, String> kPtCatalog = <String, String>{
       'Estado do Usque Engine, exportação de logs e dados locais.',
   'engine_status': 'Status do Usque Engine',
   'version': 'Versão',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Logs locais',
   'export_diagnostics': 'Exportar pacote de diagnóstico',
   'diagnostics_saved': 'Pacote de diagnóstico salvo em',

--- a/apps/usque_gui/lib/core/l10n/ru.dart
+++ b/apps/usque_gui/lib/core/l10n/ru.dart
@@ -295,7 +295,7 @@ const Map<String, String> kRuCatalog = <String, String>{
       'Состояние Usque Engine, экспорт журналов и локальные данные.',
   'engine_status': 'Состояние Usque Engine',
   'version': 'Версия',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Локальные журналы',
   'export_diagnostics': 'Экспортировать диагностический пакет',
   'diagnostics_saved': 'Диагностический пакет сохранён в',

--- a/apps/usque_gui/lib/core/l10n/th.dart
+++ b/apps/usque_gui/lib/core/l10n/th.dart
@@ -292,7 +292,7 @@ const Map<String, String> kThCatalog = <String, String>{
       'สถานะ Usque Engine การส่งออกบันทึก และข้อมูลในเครื่อง',
   'engine_status': 'สถานะ Usque Engine',
   'version': 'เวอร์ชัน',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'บันทึกในเครื่อง',
   'export_diagnostics': 'ส่งออกชุดการวินิจฉัย',
   'diagnostics_saved': 'บันทึกชุดการวินิจฉัยไปที่',

--- a/apps/usque_gui/lib/core/l10n/tr.dart
+++ b/apps/usque_gui/lib/core/l10n/tr.dart
@@ -296,7 +296,7 @@ const Map<String, String> kTrCatalog = <String, String>{
       'Usque Engine durumu, günlük dışa aktarma ve yerel veriler.',
   'engine_status': 'Usque Engine durumu',
   'version': 'Sürüm',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Yerel günlükler',
   'export_diagnostics': 'Tanılama paketini dışa aktar',
   'diagnostics_saved': 'Tanılama paketi şuraya kaydedildi',

--- a/apps/usque_gui/lib/core/l10n/uk.dart
+++ b/apps/usque_gui/lib/core/l10n/uk.dart
@@ -295,7 +295,7 @@ const Map<String, String> kUkCatalog = <String, String>{
       'Стан Usque Engine, експорт журналів і локальні дані.',
   'engine_status': 'Стан Usque Engine',
   'version': 'Версія',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Локальні журнали',
   'export_diagnostics': 'Експортувати діагностичний пакет',
   'diagnostics_saved': 'Діагностичний пакет збережено до',

--- a/apps/usque_gui/lib/core/l10n/vi.dart
+++ b/apps/usque_gui/lib/core/l10n/vi.dart
@@ -292,7 +292,7 @@ const Map<String, String> kViCatalog = <String, String>{
       'Trạng thái Usque Engine, xuất nhật ký và dữ liệu cục bộ.',
   'engine_status': 'Trạng thái Usque Engine',
   'version': 'Phiên bản',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': 'Nhật ký cục bộ',
   'export_diagnostics': 'Xuất gói chẩn đoán',
   'diagnostics_saved': 'Đã lưu gói chẩn đoán vào',

--- a/apps/usque_gui/lib/core/l10n/zh_cn.dart
+++ b/apps/usque_gui/lib/core/l10n/zh_cn.dart
@@ -266,7 +266,7 @@ const Map<String, String> kZhCnCatalog = <String, String>{
   'diagnostics_subtitle': 'Usque Engine 状态、日志导出与本地数据。',
   'engine_status': 'Usque Engine 状态',
   'version': '版本',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': '本地日志',
   'export_diagnostics': '导出诊断包',
   'diagnostics_saved': '诊断包已保存至',

--- a/apps/usque_gui/lib/core/l10n/zh_hk.dart
+++ b/apps/usque_gui/lib/core/l10n/zh_hk.dart
@@ -266,7 +266,7 @@ const Map<String, String> kZhHkCatalog = <String, String>{
   'diagnostics_subtitle': 'Usque Engine 狀態、日誌匯出及本機資料。',
   'engine_status': 'Usque Engine 狀態',
   'version': '版本',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': '本機日誌',
   'export_diagnostics': '匯出診斷套件',
   'diagnostics_saved': '診斷套件已儲存至',

--- a/apps/usque_gui/lib/core/l10n/zh_tw.dart
+++ b/apps/usque_gui/lib/core/l10n/zh_tw.dart
@@ -265,7 +265,7 @@ const Map<String, String> kZhTwCatalog = <String, String>{
   'diagnostics_subtitle': 'Usque Engine 狀態、記錄匯出與本機資料。',
   'engine_status': 'Usque Engine 狀態',
   'version': '版本',
-  'app_version': 'Usque 0.2.2',
+  'app_version': 'Usque 0.2.3',
   'logs': '本機記錄',
   'export_diagnostics': '匯出診斷套件',
   'diagnostics_saved': '診斷套件已儲存至',

--- a/apps/usque_gui/pubspec.yaml
+++ b/apps/usque_gui/pubspec.yaml
@@ -1,7 +1,7 @@
 name: usque
 description: "A native, unofficial Consumer WARP client powered by Rust."
 publish_to: 'none'
-version: 0.2.2+16
+version: 0.2.3+17
 
 environment:
   sdk: ^3.12.2

--- a/apps/usque_gui/test/app_test.dart
+++ b/apps/usque_gui/test/app_test.dart
@@ -756,14 +756,14 @@ void main() {
     final downloader = RecordingUpdateDownloader(engine);
     final controller = AppController(engine, updateDownloader: downloader);
     await controller.initialize();
-    const path = 'test-update-cache/usque-v0.2.3-android-arm64-v8a.apk';
+    const path = 'test-update-cache/usque-v0.2.4-android-arm64-v8a.apk';
     controller.updateResult = const UpdateCheckResult(
       available: true,
-      version: 'v0.2.3',
+      version: 'v0.2.4',
       package: UpdatePackage(
-        name: 'usque-v0.2.3-android-arm64-v8a.apk',
+        name: 'usque-v0.2.4-android-arm64-v8a.apk',
         downloadUrl:
-            'https://github.com/GeorgeXie2333/usque-app/releases/download/v0.2.3/usque-v0.2.3-android-arm64-v8a.apk',
+            'https://github.com/GeorgeXie2333/usque-app/releases/download/v0.2.4/usque-v0.2.4-android-arm64-v8a.apk',
         size: 1024,
         sha256:
             'a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5',
@@ -2943,13 +2943,13 @@ void main() {
         addTearDown(controller.dispose);
         controller.updateResult = const UpdateCheckResult(
           available: true,
-          version: 'v0.2.3',
+          version: 'v0.2.4',
           releaseUrl:
-              'https://github.com/GeorgeXie2333/usque-app/releases/tag/v0.2.3',
+              'https://github.com/GeorgeXie2333/usque-app/releases/tag/v0.2.4',
           package: UpdatePackage(
-            name: 'usque-v0.2.3-windows-x64-v2.msi',
+            name: 'usque-v0.2.4-windows-x64-v2.msi',
             downloadUrl:
-                'https://github.com/GeorgeXie2333/usque-app/releases/download/v0.2.3/usque-v0.2.3-windows-x64-v2.msi',
+                'https://github.com/GeorgeXie2333/usque-app/releases/download/v0.2.4/usque-v0.2.4-windows-x64-v2.msi',
             size: 20 * 1024 * 1024,
             sha256:
                 'a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5',
@@ -2967,7 +2967,7 @@ void main() {
         );
 
         await tester.pumpWidget(app());
-        expect(find.text('v0.2.3  •  x64-v2  •  20.0 MiB'), findsOneWidget);
+        expect(find.text('v0.2.4  •  x64-v2  •  20.0 MiB'), findsOneWidget);
         expect(find.byType(LinearProgressIndicator), findsOneWidget);
         expect(find.text('5.0 MiB / 20.0 MiB'), findsOneWidget);
         expect(find.text('Cancel'), findsOneWidget);

--- a/apps/usque_gui/test/update_downloader_test.dart
+++ b/apps/usque_gui/test/update_downloader_test.dart
@@ -22,7 +22,7 @@ class _CacheEngine implements EngineClient {
 }
 
 UpdatePackage _package(Uri uri, int size) => UpdatePackage(
-  name: 'usque-v0.2.3-android-arm64-v8a.apk',
+  name: 'usque-v0.2.4-android-arm64-v8a.apk',
   downloadUrl: uri.toString(),
   size: size,
   sha256: List<String>.filled(32, 'a5').join(),
@@ -202,9 +202,9 @@ void main() {
     () async {
       final productionDownloader = UpdateDownloader(_CacheEngine(root.path));
       final package = UpdatePackage(
-        name: 'usque-v0.2.3-android-arm64-v8a.apk',
+        name: 'usque-v0.2.4-android-arm64-v8a.apk',
         downloadUrl:
-            'https://attacker.invalid/releases/download/v0.2.3/usque-v0.2.3-android-arm64-v8a.apk',
+            'https://attacker.invalid/releases/download/v0.2.4/usque-v0.2.4-android-arm64-v8a.apk',
         size: 1,
         sha256: List<String>.filled(32, 'a5').join(),
         platform: 'android',

--- a/crates/usque-android/src/android_runtime.rs
+++ b/crates/usque-android/src/android_runtime.rs
@@ -16,7 +16,7 @@ use usque_core::{AddressFamily, IpSbProbe, Transport, WarpIdentity};
 use usque_core::{ReconfigureClass, classify_reconfigure};
 use usque_geo::CountryCode;
 use usque_transport::{
-    EndpointPinRefresher, GeoDirectPolicy, MasqueRuntime, MasqueTunIo, RuntimeHealth,
+    EndpointPinRefresher, GeoDirectPolicy, MasqueRuntime, MasqueTunIo, RuntimeHealth, RuntimePath,
     TrafficSnapshot, TransportError,
 };
 
@@ -25,6 +25,7 @@ use super::{
     NativeSnapshot, Profile, RECONFIGURE_NEED_ATTACH, RECONFIGURE_NEED_COLD,
     RECONFIGURE_NOT_RUNNING, RECONFIGURE_OK, START_ALREADY_RUNNING, START_INVALID_PROFILE,
     START_OK, START_PLATFORM_FAILURE, START_TRANSPORT_FAILURE, START_TUN_FAILURE, SocketProtector,
+    android_transport_failure,
 };
 
 static ENGINE: OnceLock<Mutex<Option<EngineHandle>>> = OnceLock::new();
@@ -447,7 +448,7 @@ async fn run(
         match tunnel.attach_tun() {
             Ok(tun_io) => Some(tun_io),
             Err(error) => {
-                set_transport_error(&status, &error);
+                set_transport_error_on_path(&status, &error, tunnel.path());
                 tunnel.shutdown().await;
                 return;
             }
@@ -576,8 +577,16 @@ async fn run_session(
                             break;
                         }
                     };
-                    if let Err(error) = io.send_packet(&packet[..length]).await {
-                        set_error(&status, error.to_string());
+                    let send = tokio::select! {
+                        biased;
+                        _ = cancellation.cancelled() => None,
+                        result = io.send_packet(&packet[..length]) => Some(result),
+                    };
+                    let Some(send) = send else {
+                        break;
+                    };
+                    if let Err(error) = send {
+                        set_transport_error_on_path(&status, &error, tunnel.path());
                         break;
                     }
                 }
@@ -586,13 +595,21 @@ async fn run_session(
                     let Some(tun) = tun.as_ref() else { continue; };
                     match received {
                         Ok(packet) => {
-                            if let Err(error) = write_packet(tun, &packet).await {
+                            let written = tokio::select! {
+                                biased;
+                                _ = cancellation.cancelled() => None,
+                                result = write_packet(tun, &packet) => Some(result),
+                            };
+                            let Some(written) = written else {
+                                break;
+                            };
+                            if let Err(error) = written {
                                 set_error(&status, format!("write Android TUN: {error}"));
                                 break;
                             }
                         }
                         Err(error) => {
-                            set_error(&status, error.to_string());
+                            set_transport_error_on_path(&status, &error, tunnel.path());
                             break;
                         }
                     }
@@ -655,7 +672,7 @@ async fn handle_runtime_command(
                         RECONFIGURE_OK
                     }
                     Err(error) => {
-                        set_transport_error(status, &error);
+                        set_transport_error_on_path(status, &error, tunnel.path());
                         START_TRANSPORT_FAILURE
                     }
                 },
@@ -707,7 +724,7 @@ async fn handle_runtime_command(
             let io = match tunnel.attach_tun() {
                 Ok(io) => io,
                 Err(error) => {
-                    set_transport_error(status, &error);
+                    set_transport_error_on_path(status, &error, tunnel.path());
                     let _ = reply.send(START_TRANSPORT_FAILURE);
                     return;
                 }
@@ -717,7 +734,7 @@ async fn handle_runtime_command(
             }
             if let Err(error) = tunnel.reconfigure_frontends(&next).await {
                 tunnel.detach_tun();
-                set_transport_error(status, &error);
+                set_transport_error_on_path(status, &error, tunnel.path());
                 let _ = reply.send(START_TRANSPORT_FAILURE);
                 return;
             }
@@ -854,8 +871,23 @@ fn set_error(status: &Arc<Mutex<NativeSnapshot>>, message: String) {
 }
 
 fn set_transport_error(status: &Arc<Mutex<NativeSnapshot>>, error: &TransportError) {
+    set_transport_failure(status, error, android_transport_failure(error, None));
+}
+
+fn set_transport_error_on_path(
+    status: &Arc<Mutex<NativeSnapshot>>,
+    error: &TransportError,
+    path: RuntimePath,
+) {
+    set_transport_failure(status, error, android_transport_failure(error, Some(path)));
+}
+
+fn set_transport_failure(
+    status: &Arc<Mutex<NativeSnapshot>>,
+    error: &TransportError,
+    failure: usque_core::TransportFailure,
+) {
     let message = error.to_string();
-    let failure = error.failure(None, None);
     if let Ok(mut snapshot) = status.lock() {
         snapshot.phase = "error".to_owned();
         snapshot.warning = Some(message.chars().take(512).collect());

--- a/crates/usque-android/src/lib.rs
+++ b/crates/usque-android/src/lib.rs
@@ -30,7 +30,7 @@ use jni::{
     sys::{JNI_FALSE, JNI_TRUE, jboolean, jbyteArray, jint, jlong, jstring},
 };
 use serde::{Deserialize, Serialize};
-#[cfg(target_os = "android")]
+#[cfg(any(test, target_os = "android"))]
 use usque_core::TransportFailure;
 use usque_core::{
     AppConfig, ConsumerEntitlement, ConsumerRegistrationClient, DnsMode, EndpointSettings,
@@ -40,10 +40,10 @@ use usque_core::{
     parse_manual_warp_secret, storage::ConfigStore, update::UpdateChecker,
 };
 #[cfg(target_os = "android")]
-use usque_transport::{
-    EndpointPinRefresher, TransportError, refresh_endpoint_pin_over_protected_socket,
-};
+use usque_transport::{EndpointPinRefresher, refresh_endpoint_pin_over_protected_socket};
 use usque_transport::{MasqueTlsIdentity, SocketHandle, SocketProtector};
+#[cfg(any(test, target_os = "android"))]
+use usque_transport::{RuntimePath, TransportError};
 use zeroize::Zeroizing;
 
 pub const START_OK: i32 = 0;
@@ -1953,6 +1953,17 @@ impl NativeFailure {
     }
 }
 
+#[cfg(any(test, target_os = "android"))]
+fn android_transport_failure(
+    error: &TransportError,
+    path: Option<RuntimePath>,
+) -> TransportFailure {
+    match path {
+        Some(path) => error.failure(Some(path.transport), Some(path.endpoint_family)),
+        None => error.failure(None, None),
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct NativeSnapshot {
     phase: String,
@@ -2358,6 +2369,33 @@ fn jni_command_abandoned(cancelled: &AtomicBool) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn android_transport_error_mapping_preserves_h3_and_queue_codes() {
+        let path = RuntimePath {
+            transport: usque_core::Transport::Http3,
+            endpoint_family: usque_core::AddressFamily::Ipv6,
+            ipv4_available: true,
+            ipv6_available: true,
+        };
+        let closed = android_transport_failure(&TransportError::TunnelClosed, Some(path));
+        assert_eq!(
+            closed.code,
+            usque_core::TransportFailureCode::H3ConnectionClosed
+        );
+        assert_eq!(closed.transport, Some(usque_core::Transport::Http3));
+        assert_eq!(closed.address_family, Some(usque_core::AddressFamily::Ipv6));
+
+        let saturated = android_transport_failure(&TransportError::SendQueueFull, Some(path));
+        assert_eq!(
+            saturated.code,
+            usque_core::TransportFailureCode::SendQueueFull
+        );
+        assert_ne!(
+            saturated.code,
+            usque_core::TransportFailureCode::AgentUnreachable
+        );
+    }
 
     #[test]
     fn jni_boundary_failure_default_never_reports_success() {

--- a/crates/usque-engine/src/windows_agent.rs
+++ b/crates/usque-engine/src/windows_agent.rs
@@ -16,7 +16,7 @@ use tokio::{
     net::windows::named_pipe::{ClientOptions, NamedPipeClient},
     sync::{mpsc, watch},
     task::JoinHandle,
-    time::timeout,
+    time::{sleep, timeout},
 };
 use tokio_util::sync::CancellationToken;
 use usque_core::{
@@ -79,6 +79,7 @@ const AGENT_START_RECHECK_INTERVAL: Duration = Duration::from_millis(250);
 const PUMP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_PACKET_RING_CAPACITY: u32 = 4 * 1024 * 1024;
 const PACKET_WAKE_BATCH: usize = 64;
+const PACKET_RING_RETRY_INTERVAL: Duration = Duration::from_millis(1);
 const PHYSICAL_NETWORK_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 struct WindowsVpnSocketProtector {
@@ -424,9 +425,34 @@ pub(crate) struct WindowsVpnRuntime {
 }
 
 #[derive(Clone)]
+struct WindowsPumpFailure {
+    message: String,
+    failure: TransportFailure,
+}
+
+impl WindowsPumpFailure {
+    fn agent(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            failure: TransportFailure::new(
+                TransportFailureCode::AgentUnreachable,
+                TransportStage::PlatformRecovery,
+            ),
+        }
+    }
+
+    fn transport(context: &str, error: &TransportError, path: RuntimePath) -> Self {
+        Self {
+            message: format!("{context}: {error}"),
+            failure: error.failure(Some(path.transport), Some(path.endpoint_family)),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub(crate) struct WindowsVpnMonitor {
     tunnel: ManagedTunnelMonitor,
-    pump_failure: watch::Receiver<Option<String>>,
+    pump_failure: watch::Receiver<Option<WindowsPumpFailure>>,
     agent_disconnected: watch::Receiver<bool>,
 }
 
@@ -436,17 +462,23 @@ impl WindowsVpnMonitor {
     }
 
     pub(crate) fn health(&self) -> RuntimeHealth {
-        if let Some(message) = self.pump_failure.borrow().clone() {
+        if let Some(pump_failure) = self.pump_failure.borrow().clone() {
             let transport = self.tunnel.health();
+            let path = transport.path();
+            let failure = if pump_failure.failure.transport.is_none()
+                || pump_failure.failure.address_family.is_none()
+            {
+                pump_failure
+                    .failure
+                    .on_path(path.transport, path.endpoint_family)
+            } else {
+                pump_failure.failure
+            };
             RuntimeHealth::Failed {
-                last_path: transport.path(),
+                last_path: path,
                 reconnect_count: transport.reconnect_count(),
-                message,
-                failure: TransportFailure::new(
-                    TransportFailureCode::AgentUnreachable,
-                    TransportStage::PlatformRecovery,
-                )
-                .on_path(transport.path().transport, transport.path().endpoint_family),
+                message: pump_failure.message,
+                failure,
             }
         } else {
             self.tunnel.health()
@@ -464,7 +496,8 @@ impl WindowsVpnMonitor {
     pub(crate) fn failure(&self) -> Option<String> {
         self.pump_failure
             .borrow()
-            .clone()
+            .as_ref()
+            .map(|failure| failure.message.clone())
             .or_else(|| self.tunnel.failure())
     }
 
@@ -918,6 +951,7 @@ async fn bind_agent_session(
     let mut tasks = start_packet_pumps(
         tun_io,
         Arc::clone(&mapping),
+        tunnel_monitor.clone(),
         cancellation.clone(),
         pump_failure_tx.clone(),
     );
@@ -1120,8 +1154,9 @@ fn validate_capabilities(
 fn start_packet_pumps(
     mut tun_io: MasqueTunIo,
     mapping: Arc<PacketSessionMapping>,
+    tunnel_monitor: ManagedTunnelMonitor,
     cancellation: CancellationToken,
-    failure: watch::Sender<Option<String>>,
+    failure: watch::Sender<Option<WindowsPumpFailure>>,
 ) -> Vec<JoinHandle<()>> {
     let (packet_ready_tx, mut packet_ready_rx) = mpsc::channel(1);
 
@@ -1135,11 +1170,15 @@ fn start_packet_pumps(
         .await;
         match result {
             Ok(Ok(())) => {}
-            Ok(Err(error)) => report_pump_failure(&wait_failure, &wait_cancel, error.to_string()),
+            Ok(Err(error)) => report_pump_failure(
+                &wait_failure,
+                &wait_cancel,
+                WindowsPumpFailure::agent(error.to_string()),
+            ),
             Err(error) => report_pump_failure(
                 &wait_failure,
                 &wait_cancel,
-                format!("Agent packet wait task failed: {error}"),
+                WindowsPumpFailure::agent(format!("Agent packet wait task failed: {error}")),
             ),
         }
     });
@@ -1148,6 +1187,7 @@ fn start_packet_pumps(
     let pump_cancel = cancellation.clone();
     let pump_failure = failure.clone();
     let pump_task = tokio::spawn(async move {
+        let mut ring_saturation_count = 0u64;
         loop {
             tokio::select! {
                 () = pump_cancel.cancelled() => break,
@@ -1157,7 +1197,9 @@ fn start_packet_pumps(
                             report_pump_failure(
                                 &pump_failure,
                                 &pump_cancel,
-                                "Agent packet notification channel closed".to_owned(),
+                                WindowsPumpFailure::agent(
+                                    "Agent packet notification channel closed",
+                                ),
                             );
                         }
                         break;
@@ -1168,12 +1210,21 @@ fn start_packet_pumps(
                             .try_pop(PacketDirection::AgentToEngine)
                         {
                             Ok(Some(packet)) => {
-                                if let Err(error) = tun_io.send_packet(&packet).await {
+                                let send = tokio::select! {
+                                    biased;
+                                    _ = pump_cancel.cancelled() => return,
+                                    result = tun_io.send_packet(&packet) => result,
+                                };
+                                if let Err(error) = send {
                                     if !pump_cancel.is_cancelled() {
                                         report_pump_failure(
                                             &pump_failure,
                                             &pump_cancel,
-                                            format!("failed to send a TUN packet into MASQUE: {error}"),
+                                            WindowsPumpFailure::transport(
+                                                "failed to send a TUN packet into MASQUE",
+                                                &error,
+                                                tunnel_monitor.path(),
+                                            ),
                                         );
                                     }
                                     return;
@@ -1184,7 +1235,9 @@ fn start_packet_pumps(
                                 report_pump_failure(
                                     &pump_failure,
                                     &pump_cancel,
-                                    format!("Agent-to-Engine packet ring failed: {error}"),
+                                    WindowsPumpFailure::agent(format!(
+                                        "Agent-to-Engine packet ring failed: {error}"
+                                    )),
                                 );
                                 return;
                             }
@@ -1194,13 +1247,22 @@ fn start_packet_pumps(
                 packet = tun_io.receive_packet() => {
                     match packet {
                         Ok(packet) => {
-                            if let Err(message) = publish_engine_packet_batch(
+                            match publish_engine_packet_batch(
                                 &mut tun_io,
                                 &pump_mapping,
+                                &tunnel_monitor,
+                                &pump_cancel,
+                                &mut ring_saturation_count,
                                 packet,
-                            ) {
-                                report_pump_failure(&pump_failure, &pump_cancel, message);
-                                break;
+                            )
+                            .await
+                            {
+                                Ok(true) => {}
+                                Ok(false) => break,
+                                Err(failure) => {
+                                    report_pump_failure(&pump_failure, &pump_cancel, failure);
+                                    break;
+                                }
                             }
                         }
                         Err(error) => {
@@ -1208,7 +1270,11 @@ fn start_packet_pumps(
                                 report_pump_failure(
                                     &pump_failure,
                                     &pump_cancel,
-                                    format!("failed to receive a MASQUE packet: {error}"),
+                                    WindowsPumpFailure::transport(
+                                        "failed to receive a MASQUE packet",
+                                        &error,
+                                        tunnel_monitor.path(),
+                                    ),
                                 );
                             }
                             break;
@@ -1223,35 +1289,70 @@ fn start_packet_pumps(
     vec![wait_task, pump_task]
 }
 
-fn publish_engine_packet_batch(
+async fn publish_engine_packet_batch(
     tun_io: &mut MasqueTunIo,
     mapping: &PacketSessionMapping,
+    tunnel_monitor: &ManagedTunnelMonitor,
+    cancellation: &CancellationToken,
+    saturation_count: &mut u64,
     first: Bytes,
-) -> Result<(), String> {
+) -> Result<bool, WindowsPumpFailure> {
     let ring = mapping.ring();
     let wake_bytes = (ring.capacity() as usize / 4).max(1);
     let mut packet = first;
     let mut published = false;
     let mut published_bytes = 0usize;
     let mut packet_count = 0usize;
-    let result: Result<(), String> = loop {
-        match ring.try_push(PacketDirection::EngineToAgent, &packet) {
-            Ok(pushed) => {
-                published |= pushed;
-                if pushed {
-                    published_bytes = published_bytes.saturating_add(packet.len());
+    let result: Result<bool, WindowsPumpFailure> = 'batch: loop {
+        loop {
+            match ring.try_push_preserving(PacketDirection::EngineToAgent, &packet) {
+                Ok(true) => break,
+                Ok(false) => {
+                    if published {
+                        mapping
+                            .signal_engine_to_agent()
+                            .map_err(|error| WindowsPumpFailure::agent(error.to_string()))?;
+                        published = false;
+                        published_bytes = 0;
+                        packet_count = 0;
+                    }
+                    *saturation_count = saturation_count.saturating_add(1);
+                    if saturation_count.is_power_of_two() {
+                        tracing::warn!(
+                            wait_count = *saturation_count,
+                            ring_capacity = ring.capacity(),
+                            "waiting for capacity in the Engine-to-Agent packet ring"
+                        );
+                    }
+                    tokio::select! {
+                        biased;
+                        _ = cancellation.cancelled() => break 'batch Ok(false),
+                        () = sleep(PACKET_RING_RETRY_INTERVAL) => {}
+                    }
+                }
+                Err(error) => {
+                    break 'batch Err(WindowsPumpFailure::agent(format!(
+                        "Engine-to-Agent packet ring failed: {error}"
+                    )));
                 }
             }
-            Err(error) => break Err(format!("Engine-to-Agent packet ring failed: {error}")),
         }
+        published = true;
+        published_bytes = published_bytes.saturating_add(packet.len());
         packet_count += 1;
         if packet_count == PACKET_WAKE_BATCH || published_bytes >= wake_bytes {
-            break Ok(());
+            break 'batch Ok(true);
         }
         match tun_io.try_receive_packet() {
             Ok(Some(next)) => packet = next,
-            Ok(None) => break Ok(()),
-            Err(error) => break Err(format!("failed to receive a MASQUE packet: {error}")),
+            Ok(None) => break 'batch Ok(true),
+            Err(error) => {
+                break 'batch Err(WindowsPumpFailure::transport(
+                    "failed to receive a MASQUE packet",
+                    &error,
+                    tunnel_monitor.path(),
+                ));
+            }
         }
     };
 
@@ -1260,18 +1361,18 @@ fn publish_engine_packet_batch(
         // until empty, so coalesced auto-reset signals cannot strand packets.
         mapping
             .signal_engine_to_agent()
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| WindowsPumpFailure::agent(error.to_string()))?;
     }
     result
 }
 
 fn report_pump_failure(
-    failure: &watch::Sender<Option<String>>,
+    failure: &watch::Sender<Option<WindowsPumpFailure>>,
     cancellation: &CancellationToken,
-    message: String,
+    pump_failure: WindowsPumpFailure,
 ) {
     if failure.borrow().is_none() {
-        failure.send_replace(Some(message));
+        failure.send_replace(Some(pump_failure));
     }
     cancellation.cancel();
 }
@@ -1280,7 +1381,7 @@ fn start_agent_liveness_watch(
     mut pipe: NamedPipeClient,
     mapping: Arc<PacketSessionMapping>,
     cancellation: CancellationToken,
-    failure: watch::Sender<Option<String>>,
+    failure: watch::Sender<Option<WindowsPumpFailure>>,
     agent_disconnected: watch::Sender<bool>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -1299,7 +1400,7 @@ fn start_agent_liveness_watch(
             Ok(_) => "Windows Agent sent unexpected liveness data".to_owned(),
             Err(error) => format!("Windows Agent service connection failed: {error}"),
         };
-        report_pump_failure(&failure, &cancellation, message);
+        report_pump_failure(&failure, &cancellation, WindowsPumpFailure::agent(message));
     })
 }
 
@@ -2287,9 +2388,48 @@ mod tests {
     };
 
     use tokio::net::windows::named_pipe::ServerOptions;
-    use usque_core::{MasqueKeyPair, OperatingMode};
+    use usque_core::{AddressFamily, MasqueKeyPair, OperatingMode, Transport};
 
     use super::*;
+
+    #[test]
+    fn packet_pump_transport_failures_keep_the_active_transport_code() {
+        let path = RuntimePath {
+            transport: Transport::Http3,
+            endpoint_family: AddressFamily::Ipv4,
+            ipv4_available: true,
+            ipv6_available: true,
+        };
+        let closed = WindowsPumpFailure::transport(
+            "receive MASQUE packet",
+            &TransportError::TunnelClosed,
+            path,
+        );
+        assert_eq!(
+            closed.failure.code,
+            TransportFailureCode::H3ConnectionClosed
+        );
+        assert_eq!(closed.failure.transport, Some(Transport::Http3));
+        assert_eq!(closed.failure.address_family, Some(AddressFamily::Ipv4));
+
+        let saturated = WindowsPumpFailure::transport(
+            "send MASQUE packet",
+            &TransportError::SendQueueFull,
+            path,
+        );
+        assert_eq!(saturated.failure.code, TransportFailureCode::SendQueueFull);
+        assert_ne!(
+            saturated.failure.code,
+            TransportFailureCode::AgentUnreachable
+        );
+    }
+
+    #[test]
+    fn only_agent_liveness_failures_use_agent_unreachable() {
+        let failure = WindowsPumpFailure::agent("agent pipe closed");
+        assert_eq!(failure.failure.code, TransportFailureCode::AgentUnreachable);
+        assert_eq!(failure.failure.stage, TransportStage::PlatformRecovery);
+    }
 
     struct StartingTestController {
         pipe_name: String,

--- a/crates/usque-platform/src/packet_ring.rs
+++ b/crates/usque-platform/src/packet_ring.rs
@@ -151,6 +151,25 @@ impl SharedPacketRing {
         direction: PacketDirection,
         packet: &[u8],
     ) -> Result<bool, PacketRingError> {
+        self.try_push_inner(direction, packet, true)
+    }
+
+    /// Attempts to publish a packet while leaving overflow accounting to a
+    /// caller that retains and retries the packet.
+    pub fn try_push_preserving(
+        &self,
+        direction: PacketDirection,
+        packet: &[u8],
+    ) -> Result<bool, PacketRingError> {
+        self.try_push_inner(direction, packet, false)
+    }
+
+    fn try_push_inner(
+        &self,
+        direction: PacketDirection,
+        packet: &[u8],
+        count_drop: bool,
+    ) -> Result<bool, PacketRingError> {
         if packet.is_empty() || packet.len() > MAX_PACKET_BYTES {
             return Err(PacketRingError::PacketSize(packet.len()));
         }
@@ -167,7 +186,9 @@ impl SharedPacketRing {
             });
         }
         if required as u32 > self.capacity - used {
-            dropped.fetch_add(1, Ordering::Relaxed);
+            if count_drop {
+                dropped.fetch_add(1, Ordering::Relaxed);
+            }
             return Ok(false);
         }
 
@@ -528,6 +549,29 @@ mod tests {
                 .expect("packet"),
             packet
         );
+    }
+
+    #[test]
+    fn preserving_push_can_retry_without_counting_a_drop() {
+        let (_memory, ring) = AlignedMemory::ring(MIN_RING_CAPACITY);
+        let packet = vec![0x45; MAX_PACKET_BYTES];
+        while ring
+            .try_push_preserving(PacketDirection::EngineToAgent, &packet)
+            .expect("fill")
+        {}
+        assert_eq!(ring.dropped(PacketDirection::EngineToAgent), 0);
+
+        assert_eq!(
+            ring.try_pop(PacketDirection::EngineToAgent)
+                .expect("pop")
+                .expect("packet"),
+            packet
+        );
+        assert!(
+            ring.try_push_preserving(PacketDirection::EngineToAgent, b"retained")
+                .expect("retry")
+        );
+        assert_eq!(ring.dropped(PacketDirection::EngineToAgent), 0);
     }
 
     #[test]

--- a/crates/usque-transport/src/fault_injection.rs
+++ b/crates/usque-transport/src/fault_injection.rs
@@ -102,6 +102,7 @@ pub struct FaultHarness {
     send_queue_capacity: usize,
     send_queue_depth: usize,
     send_queue_high_watermark: usize,
+    send_queue_waits: u64,
     send_queue_drops: u64,
 }
 
@@ -122,6 +123,7 @@ impl FaultHarness {
             send_queue_capacity,
             send_queue_depth: 0,
             send_queue_high_watermark: 0,
+            send_queue_waits: 0,
             send_queue_drops: 0,
         })
     }
@@ -285,11 +287,8 @@ impl FaultHarness {
         if self.active.contains(&FaultKind::FillSendQueue)
             || self.send_queue_depth == self.send_queue_capacity
         {
-            self.send_queue_drops = self.send_queue_drops.saturating_add(1);
-            return Err(TransportFailure::new(
-                TransportFailureCode::SendQueueFull,
-                TransportStage::PacketSend,
-            ));
+            self.send_queue_waits = self.send_queue_waits.saturating_add(1);
+            return Ok(());
         }
         self.send_queue_depth += 1;
         self.send_queue_high_watermark = self.send_queue_high_watermark.max(self.send_queue_depth);
@@ -297,7 +296,11 @@ impl FaultHarness {
     }
 
     pub fn complete_send(&mut self) {
-        self.send_queue_depth = self.send_queue_depth.saturating_sub(1);
+        if self.send_queue_waits != 0 {
+            self.send_queue_waits -= 1;
+        } else {
+            self.send_queue_depth = self.send_queue_depth.saturating_sub(1);
+        }
     }
 
     pub fn receive_packet(&self) -> Result<(), TransportFailure> {
@@ -340,6 +343,10 @@ impl FaultHarness {
 
     pub const fn send_queue_drops(&self) -> u64 {
         self.send_queue_drops
+    }
+
+    pub const fn send_queue_waits(&self) -> u64 {
+        self.send_queue_waits
     }
 
     pub const fn send_queue_depth(&self) -> usize {
@@ -471,19 +478,38 @@ mod tests {
     }
 
     #[test]
-    fn send_queue_is_bounded_and_saturation_is_counted() {
+    fn send_queue_saturation_waits_without_dropping_or_failing() {
         let mut harness = harness(Vec::new());
         harness.send_packet().unwrap();
         harness.send_packet().unwrap();
-        let failure = harness
-            .send_packet()
-            .expect_err("bounded queue must reject");
-        assert_eq!(failure.code, TransportFailureCode::SendQueueFull);
+        harness.send_packet().unwrap();
         assert_eq!(harness.send_queue_high_watermark(), 2);
-        assert_eq!(harness.send_queue_drops(), 1);
+        assert_eq!(harness.send_queue_waits(), 1);
+        assert_eq!(harness.send_queue_drops(), 0);
+        harness.complete_send();
+        assert_eq!(harness.send_queue_depth(), 2);
+        assert_eq!(harness.send_queue_waits(), 0);
         harness.complete_send();
         harness.complete_send();
         assert_eq!(harness.send_queue_depth(), 0);
+    }
+
+    #[test]
+    fn burst_beyond_1024_packets_remains_recoverable() {
+        let script = FaultScript::new(0x5eed, Vec::new()).unwrap();
+        let mut harness = FaultHarness::new(script, 1_024).unwrap();
+        for _ in 0..=1_024 {
+            harness.send_packet().unwrap();
+        }
+        assert_eq!(harness.send_queue_depth(), 1_024);
+        assert_eq!(harness.send_queue_waits(), 1);
+        assert_eq!(harness.send_queue_drops(), 0);
+
+        for _ in 0..=1_024 {
+            harness.complete_send();
+        }
+        assert_eq!(harness.send_queue_depth(), 0);
+        assert_eq!(harness.send_queue_waits(), 0);
     }
 
     #[test]

--- a/crates/usque-transport/src/h2.rs
+++ b/crates/usque-transport/src/h2.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
+use std::future::Future;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -33,6 +35,7 @@ use usque_protocol::{ConnectIpCapsule, MAX_CAPSULE_PAYLOAD, PeerNetworkState};
 use zeroize::Zeroizing;
 
 use crate::connect_ip_control::ConnectIpControlPlane;
+use crate::packet_batch::{PacketBatch, PacketBatchResult};
 use crate::socket::{SocketProtector, noop_socket_protector, socket_handle};
 use crate::telemetry::{ConnectionAttemptTelemetry, ConnectionEventType};
 
@@ -42,6 +45,7 @@ const DATAGRAM_CAPSULE_TYPE: u64 = 0;
 const MAX_CAPSULE_BYTES: usize = 65_535;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(8);
 const H2_OUTGOING_CAPACITY: usize = 1_024;
+const H2_PACKET_QUEUE_CAPACITY: usize = 1_024;
 const PACKET_SEND_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Secret and enrolled identity material required by a MASQUE TLS session.
@@ -104,7 +108,8 @@ impl H2Tunnel {
 
 struct H2Outgoing {
     bytes: Bytes,
-    completion: oneshot::Sender<Result<(), TransportError>>,
+    accepted_bytes: usize,
+    completion: oneshot::Sender<Result<usize, TransportError>>,
 }
 
 pub struct H2SendHalf {
@@ -116,7 +121,15 @@ impl H2SendHalf {
     /// Sends one raw IP packet as an HTTP Capsule DATAGRAM.
     pub async fn send_packet(&mut self, packet: &[u8]) -> Result<(), TransportError> {
         validate_ip_packet(packet)?;
-        self.send_capsule(encode_datagram_capsule(packet)?).await
+        match timeout(
+            PACKET_SEND_TIMEOUT,
+            self.send_owned_batch(PacketBatch::single(Bytes::copy_from_slice(packet))),
+        )
+        .await
+        {
+            Ok(result) => result.map(|_| ()),
+            Err(_) => Err(TransportError::SendTimeout),
+        }
     }
 
     /// Writes one already-framed Capsule Protocol record on the CONNECT-IP
@@ -129,26 +142,53 @@ impl H2SendHalf {
         }
     }
 
-    /// Sends an owned packet under the transport supervisor's outer deadline.
-    pub(crate) async fn send_owned_packet(&mut self, packet: Bytes) -> Result<(), TransportError> {
-        validate_ip_packet(&packet)?;
-        self.send_capsule_inner(encode_datagram_capsule(&packet)?)
-            .await
+    pub(crate) async fn send_owned_batch(
+        &self,
+        batch: PacketBatch,
+    ) -> Result<PacketBatchResult, TransportError> {
+        self.start_owned_batch(batch).await
     }
 
-    async fn send_capsule_inner(&mut self, capsule: Bytes) -> Result<(), TransportError> {
-        let (completion_tx, completion_rx) = oneshot::channel();
-        self.sender
-            .as_ref()
-            .ok_or(TransportError::TunnelClosed)?
-            .try_send(H2Outgoing {
-                bytes: capsule,
-                completion: completion_tx,
+    pub(crate) fn start_owned_batch(
+        &self,
+        batch: PacketBatch,
+    ) -> Pin<Box<dyn Future<Output = Result<PacketBatchResult, TransportError>> + Send + 'static>>
+    {
+        let sender = self.sender.clone();
+        Box::pin(async move {
+            if batch.is_empty() {
+                return Ok(PacketBatchResult::default());
+            }
+            let (encoded, accepted_bytes) = encode_datagram_batch(&batch)?;
+            let accepted_bytes = Self::send_encoded(sender, encoded, accepted_bytes).await?;
+            Ok(PacketBatchResult {
+                accepted_bytes,
+                oversized: Vec::new(),
             })
-            .map_err(|error| match error {
-                mpsc::error::TrySendError::Full(_) => TransportError::SendQueueFull,
-                mpsc::error::TrySendError::Closed(_) => TransportError::TunnelClosed,
-            })?;
+        })
+    }
+
+    async fn send_capsule_inner(&self, capsule: Bytes) -> Result<(), TransportError> {
+        Self::send_encoded(self.sender.clone(), capsule, 0).await?;
+        Ok(())
+    }
+
+    async fn send_encoded(
+        sender: Option<mpsc::Sender<H2Outgoing>>,
+        bytes: Bytes,
+        accepted_bytes: usize,
+    ) -> Result<usize, TransportError> {
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let sender = sender.ok_or(TransportError::TunnelClosed)?;
+        let permit = sender
+            .reserve()
+            .await
+            .map_err(|_| TransportError::TunnelClosed)?;
+        permit.send(H2Outgoing {
+            bytes,
+            accepted_bytes,
+            completion: completion_tx,
+        });
         match completion_rx.await {
             Ok(result) => result,
             Err(_) => Err(TransportError::TunnelClosed),
@@ -191,8 +231,23 @@ impl H2ReceiveHalf {
         }
     }
 
+    pub(crate) async fn receive_batch(&mut self) -> Result<PacketBatch, TransportError> {
+        let first = self.receive_packet().await?;
+        let mut batch = PacketBatch::single(first);
+        while let Some(packet) = self.packets.pop_front() {
+            if let Err(packet) = batch.push_back(packet) {
+                self.packets.push_front(packet);
+                break;
+            }
+        }
+        Ok(batch)
+    }
+
     fn drain_ready_capsules(&mut self) -> Result<(), TransportError> {
         loop {
+            if self.packets.len() >= H2_PACKET_QUEUE_CAPACITY {
+                return Ok(());
+            }
             let Some(capsule) = take_complete_capsule(&mut self.control.buffer)? else {
                 return Ok(());
             };
@@ -229,9 +284,11 @@ pub struct H2Driver {
 
 impl H2Driver {
     pub async fn wait(mut self) -> Result<(), TransportError> {
-        self.task
+        let task = self
+            .task
             .take()
-            .expect("H2 driver task is present until wait")
+            .expect("H2 driver task is present until wait");
+        AbortOnDropHandle::new(task)
             .await
             .map_err(|error| TransportError::Driver(error.to_string()))?
             .map_err(TransportError::Http2)
@@ -398,8 +455,10 @@ async fn run_h2_writer(
             }
             item = outgoing.recv() => {
                 match item {
-                    Some(H2Outgoing { bytes, completion }) => {
-                        let result = write_h2_data(&mut stream, bytes).await;
+                    Some(H2Outgoing { bytes, accepted_bytes, completion }) => {
+                        let result = write_h2_data(&mut stream, bytes)
+                            .await
+                            .map(|()| accepted_bytes);
                         let _ = completion.send(result);
                     }
                     None => {
@@ -430,12 +489,32 @@ async fn write_h2_data(
     Ok(())
 }
 
+#[cfg(test)]
 fn encode_datagram_capsule(packet: &[u8]) -> Result<Bytes, TransportError> {
     let mut encoded = BytesMut::with_capacity(packet.len() + 16);
-    encode_varint(DATAGRAM_CAPSULE_TYPE, &mut encoded)?;
-    encode_varint(packet.len() as u64, &mut encoded)?;
-    encoded.extend_from_slice(packet);
+    encode_datagram_capsule_into(packet, &mut encoded)?;
     Ok(encoded.freeze())
+}
+
+fn encode_datagram_batch(batch: &PacketBatch) -> Result<(Bytes, usize), TransportError> {
+    let accepted_bytes = batch.bytes();
+    let mut encoded =
+        BytesMut::with_capacity(accepted_bytes.saturating_add(batch.len().saturating_mul(16)));
+    for packet in batch.iter() {
+        validate_ip_packet(packet)?;
+        encode_datagram_capsule_into(packet, &mut encoded)?;
+    }
+    Ok((encoded.freeze(), accepted_bytes))
+}
+
+fn encode_datagram_capsule_into(
+    packet: &[u8],
+    encoded: &mut BytesMut,
+) -> Result<(), TransportError> {
+    encode_varint(DATAGRAM_CAPSULE_TYPE, encoded)?;
+    encode_varint(packet.len() as u64, encoded)?;
+    encoded.extend_from_slice(packet);
+    Ok(())
 }
 
 fn connect_request() -> Result<Request<()>, http::Error> {
@@ -976,6 +1055,33 @@ mod tests {
     }
 
     #[test]
+    fn h2_batch_preserves_packet_order_and_capsule_wire_format() {
+        let mut ipv4 = vec![0u8; 20];
+        ipv4[0] = 0x45;
+        ipv4[2..4].copy_from_slice(&20_u16.to_be_bytes());
+        ipv4[8] = 64;
+        ipv4[9] = 17;
+        let mut ipv6 = vec![0u8; 40];
+        ipv6[0] = 0x60;
+        ipv6[7] = 64;
+
+        let mut batch = PacketBatch::new();
+        batch.push_back(Bytes::from(ipv4.clone())).unwrap();
+        batch.push_back(Bytes::from(ipv6.clone())).unwrap();
+        let (encoded, accepted_bytes) = encode_datagram_batch(&batch).unwrap();
+        assert_eq!(accepted_bytes, ipv4.len() + ipv6.len());
+
+        let (first_type, first, consumed) = decode_capsule(&encoded).unwrap().unwrap();
+        assert_eq!(first_type, DATAGRAM_CAPSULE_TYPE);
+        assert_eq!(first.as_ref(), ipv4);
+        let (second_type, second, final_consumed) =
+            decode_capsule(&encoded[consumed..]).unwrap().unwrap();
+        assert_eq!(second_type, DATAGRAM_CAPSULE_TYPE);
+        assert_eq!(second.as_ref(), ipv6);
+        assert_eq!(consumed + final_consumed, encoded.len());
+    }
+
+    #[test]
     fn streaming_capsule_take_is_transactional_until_a_frame_is_complete() {
         let first = ConnectIpCapsule::Unknown {
             capsule_type: 42,
@@ -1191,6 +1297,46 @@ mod tests {
             buffer.extend_from_slice(&chunk);
             stream.flow_control().release_capacity(length).unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn h2_parsed_packet_queue_stops_at_1024_without_consuming_the_tail() {
+        let mut loopback = connect_h2_loopback().await;
+        let mut wire = BytesMut::new();
+        let mut final_capsule = Bytes::new();
+        for sequence in 0..=H2_PACKET_QUEUE_CAPACITY as u16 {
+            let mut packet = ipv4_packet();
+            packet[4..6].copy_from_slice(&sequence.to_be_bytes());
+            let capsule = encode_datagram_capsule(&packet).unwrap();
+            if usize::from(sequence) == H2_PACKET_QUEUE_CAPACITY {
+                final_capsule = capsule.clone();
+            }
+            wire.extend_from_slice(&capsule);
+        }
+        loopback.receive.control.buffer.extend_from_slice(&wire);
+
+        loopback.receive.drain_ready_capsules().unwrap();
+        assert_eq!(loopback.receive.packets.len(), H2_PACKET_QUEUE_CAPACITY);
+        assert_eq!(loopback.receive.control.buffer, final_capsule);
+        assert_eq!(
+            u16::from_be_bytes([
+                loopback.receive.packets.front().unwrap()[4],
+                loopback.receive.packets.front().unwrap()[5],
+            ]),
+            0
+        );
+
+        loopback.receive.packets.pop_front();
+        loopback.receive.drain_ready_capsules().unwrap();
+        assert_eq!(loopback.receive.packets.len(), H2_PACKET_QUEUE_CAPACITY);
+        assert!(loopback.receive.control.buffer.is_empty());
+        assert_eq!(
+            u16::from_be_bytes([
+                loopback.receive.packets.back().unwrap()[4],
+                loopback.receive.packets.back().unwrap()[5],
+            ]),
+            H2_PACKET_QUEUE_CAPACITY as u16
+        );
     }
 
     #[tokio::test]

--- a/crates/usque-transport/src/h3.rs
+++ b/crates/usque-transport/src/h3.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
+use std::future::Future;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket as StdUdpSocket};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant};
 
@@ -21,6 +23,7 @@ use crate::h2::{
     MasqueTlsIdentity, PinState, TransportError, configure_client_identity_and_pin,
     validate_ip_packet,
 };
+use crate::packet_batch::{MAX_PACKET_BATCH_PACKETS, PacketBatch, PacketBatchResult};
 use crate::socket::{SocketProtector, noop_socket_protector, socket_handle};
 use crate::telemetry::{ConnectionAttemptTelemetry, ConnectionEventType};
 
@@ -34,8 +37,15 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(8);
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_IDLE_TIMEOUT_MS: u64 = 90_000;
 const MAX_UDP_PAYLOAD_SIZE: usize = 1_350;
-const DATAGRAM_CHANNEL_CAPACITY: usize = 1_024;
+const DATAGRAM_SEND_QUEUE_CAPACITY: usize = 1_024;
+const DATAGRAM_RECV_QUEUE_CAPACITY: usize = MAX_PACKET_BATCH_PACKETS;
+const INBOUND_PACKET_CAPACITY: usize = 1_024;
+const INBOUND_RESERVED_BATCHES: usize = 3;
+const INCOMING_BATCH_CHANNEL_CAPACITY: usize =
+    INBOUND_PACKET_CAPACITY / MAX_PACKET_BATCH_PACKETS - INBOUND_RESERVED_BATCHES;
+const OUTGOING_BATCH_CHANNEL_CAPACITY: usize = 1;
 const MAX_PENDING_WIRE_DATAGRAMS: usize = 64;
+const MAX_SOCKET_DRAIN: usize = 64;
 const PACKET_SEND_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// An established Cloudflare CONNECT-IP stream over HTTP/3 and QUIC.
@@ -64,7 +74,7 @@ impl H3Tunnel {
 }
 
 pub struct H3SendHalf {
-    sender: Option<mpsc::Sender<OutgoingPacket>>,
+    sender: Option<mpsc::Sender<OutgoingBatch>>,
 }
 
 impl H3SendHalf {
@@ -80,34 +90,53 @@ impl H3SendHalf {
         }
     }
 
-    /// Sends an owned packet under the transport supervisor's outer deadline.
-    pub(crate) async fn send_owned_packet(&mut self, packet: Bytes) -> Result<(), TransportError> {
-        self.send_owned_packet_inner(packet).await
-    }
-
     async fn send_owned_packet_inner(&mut self, packet: Bytes) -> Result<(), TransportError> {
         validate_ip_packet(&packet)?;
-        let (completion_tx, completion_rx) = oneshot::channel();
-        self.sender
-            .as_ref()
-            .ok_or(TransportError::TunnelClosed)?
-            .try_send(OutgoingPacket {
-                packet,
-                completion: completion_tx,
-            })
-            .map_err(|error| match error {
-                TrySendError::Full(_) => TransportError::SendQueueFull,
-                TrySendError::Closed(_) => TransportError::TunnelClosed,
-            })?;
-        match completion_rx.await {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(DatagramSendFailure::TooLarge {
+        let mut result = self.send_owned_batch(PacketBatch::single(packet)).await?;
+        if let Some((_packet, maximum_packet_size)) = result.oversized.pop() {
+            return Err(TransportError::Http3DatagramTooLarge {
                 maximum_packet_size,
-            })) => Err(TransportError::Http3DatagramTooLarge {
-                maximum_packet_size,
-            }),
-            Err(_) => Err(TransportError::TunnelClosed),
+            });
         }
+        Ok(())
+    }
+
+    pub(crate) async fn send_owned_batch(
+        &self,
+        batch: PacketBatch,
+    ) -> Result<PacketBatchResult, TransportError> {
+        self.start_owned_batch(batch).await
+    }
+
+    pub(crate) fn start_owned_batch(
+        &self,
+        batch: PacketBatch,
+    ) -> Pin<Box<dyn Future<Output = Result<PacketBatchResult, TransportError>> + Send + 'static>>
+    {
+        let sender = self.sender.clone();
+        Box::pin(async move {
+            if batch.is_empty() {
+                return Ok(PacketBatchResult::default());
+            }
+            for packet in batch.iter() {
+                validate_ip_packet(packet)?;
+            }
+            let (completion_tx, completion_rx) = oneshot::channel();
+            let sender = sender.ok_or(TransportError::TunnelClosed)?;
+            let permit = sender
+                .reserve()
+                .await
+                .map_err(|_| TransportError::TunnelClosed)?;
+            permit.send(OutgoingBatch {
+                batch,
+                result: PacketBatchResult::default(),
+                completion: completion_tx,
+            });
+            match completion_rx.await {
+                Ok(result) => Ok(result),
+                Err(_) => Err(TransportError::TunnelClosed),
+            }
+        })
     }
 
     pub fn close(&mut self) {
@@ -115,21 +144,35 @@ impl H3SendHalf {
     }
 }
 
-struct OutgoingPacket {
-    packet: Bytes,
-    completion: oneshot::Sender<Result<(), DatagramSendFailure>>,
-}
-
-enum DatagramSendFailure {
-    TooLarge { maximum_packet_size: usize },
+struct OutgoingBatch {
+    batch: PacketBatch,
+    result: PacketBatchResult,
+    completion: oneshot::Sender<PacketBatchResult>,
 }
 
 pub struct H3ReceiveHalf {
-    receiver: mpsc::Receiver<Bytes>,
+    receiver: mpsc::Receiver<PacketBatch>,
+    pending: PacketBatch,
 }
 
 impl H3ReceiveHalf {
     pub async fn receive_packet(&mut self) -> Result<Bytes, TransportError> {
+        loop {
+            if let Some(packet) = self.pending.pop_front() {
+                return Ok(packet);
+            }
+            self.pending = self
+                .receiver
+                .recv()
+                .await
+                .ok_or(TransportError::TunnelClosed)?;
+        }
+    }
+
+    pub(crate) async fn receive_batch(&mut self) -> Result<PacketBatch, TransportError> {
+        if !self.pending.is_empty() {
+            return Ok(std::mem::take(&mut self.pending));
+        }
         self.receiver
             .recv()
             .await
@@ -143,9 +186,11 @@ pub struct H3Driver {
 
 impl H3Driver {
     pub async fn wait(mut self) -> Result<(), TransportError> {
-        self.task
+        let task = self
+            .task
             .take()
-            .expect("H3 driver task is present until wait")
+            .expect("H3 driver task is present until wait");
+        AbortOnDropHandle::new(task)
             .await
             .map_err(|error| TransportError::Http3(format!("driver task failed: {error}")))?
     }
@@ -243,8 +288,8 @@ async fn connect_h3_once(
     h3_config.set_qpack_max_table_capacity(0);
     h3_config.set_qpack_blocked_streams(0);
 
-    let (outgoing_tx, outgoing_rx) = mpsc::channel(DATAGRAM_CHANNEL_CAPACITY);
-    let (incoming_tx, incoming_rx) = mpsc::channel(DATAGRAM_CHANNEL_CAPACITY);
+    let (outgoing_tx, outgoing_rx) = mpsc::channel(OUTGOING_BATCH_CHANNEL_CAPACITY);
+    let (incoming_tx, incoming_rx) = mpsc::channel(INCOMING_BATCH_CHANNEL_CAPACITY);
     let (control_tx, control_rx) = watch::channel(PeerNetworkState::default());
     let (startup_tx, startup_rx) = oneshot::channel();
     let task = AbortOnDropHandle::new(tokio::spawn(run_h3_actor(
@@ -266,6 +311,7 @@ async fn connect_h3_once(
             },
             receive: H3ReceiveHalf {
                 receiver: incoming_rx,
+                pending: PacketBatch::new(),
             },
             driver: H3Driver {
                 task: Some(task.detach()),
@@ -328,7 +374,11 @@ fn quic_config(
     config.set_initial_max_streams_bidi(16);
     config.set_initial_max_streams_uni(16);
     config.set_disable_active_migration(true);
-    config.enable_dgram(true, DATAGRAM_CHANNEL_CAPACITY, DATAGRAM_CHANNEL_CAPACITY);
+    config.enable_dgram(
+        true,
+        DATAGRAM_RECV_QUEUE_CAPACITY,
+        DATAGRAM_SEND_QUEUE_CAPACITY,
+    );
     config.set_cc_algorithm(quiche::CongestionControlAlgorithm::CUBIC);
     config.enable_pacing(true);
     Ok((config, pin_state))
@@ -372,8 +422,8 @@ async fn run_h3_actor(
     socket: UdpSocket,
     connection: quiche::Connection,
     h3_config: quiche::h3::Config,
-    outgoing_rx: mpsc::Receiver<OutgoingPacket>,
-    incoming_tx: mpsc::Sender<Bytes>,
+    outgoing_rx: mpsc::Receiver<OutgoingBatch>,
+    incoming_tx: mpsc::Sender<PacketBatch>,
     control_tx: watch::Sender<PeerNetworkState>,
     startup_tx: oneshot::Sender<Result<(), StartupFailure>>,
     attempt: Option<ConnectionAttemptTelemetry>,
@@ -410,8 +460,8 @@ async fn drive_h3_actor(
     socket: UdpSocket,
     mut connection: quiche::Connection,
     h3_config: quiche::h3::Config,
-    mut outgoing_rx: mpsc::Receiver<OutgoingPacket>,
-    incoming_tx: mpsc::Sender<Bytes>,
+    mut outgoing_rx: mpsc::Receiver<OutgoingBatch>,
+    incoming_tx: mpsc::Sender<PacketBatch>,
     control_tx: watch::Sender<PeerNetworkState>,
     startup_tx: &mut Option<oneshot::Sender<Result<(), StartupFailure>>>,
     attempt: Option<&ConnectionAttemptTelemetry>,
@@ -423,11 +473,12 @@ async fn drive_h3_actor(
     let mut peer_settings_recorded = false;
     let mut ready = false;
     let mut control = ConnectIpControlPlane::new(control_tx);
-    let mut pending_packet: Option<OutgoingPacket> = None;
+    let mut pending_batch: Option<OutgoingBatch> = None;
     let mut wire_datagrams = VecDeque::with_capacity(MAX_PENDING_WIRE_DATAGRAMS);
     let mut free_wire_buffers = Vec::new();
     let mut receive_buffer = vec![0u8; 65_535];
-    let mut inbound_dropped_packets = 0u64;
+    let mut incoming_batch = PacketBatch::new();
+    let mut inbound_queue_drop_count = 0_u64;
     let mut keepalive = interval_at(Instant::now() + KEEPALIVE_INTERVAL, KEEPALIVE_INTERVAL);
     keepalive.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
@@ -507,44 +558,21 @@ async fn drive_h3_actor(
                 stream_id,
                 ready,
                 &incoming_tx,
-                &mut receive_buffer,
-                &mut inbound_dropped_packets,
+                &mut incoming_batch,
             )?;
         }
 
-        if ready
-            && let (Some(stream_id), Some(packet)) = (request_stream_id, pending_packet.as_ref())
-        {
-            let datagram = encode_http_datagram(stream_id, &packet.packet)?;
-            let datagram_overhead = datagram.len().saturating_sub(packet.packet.len());
-            let maximum_packet_size = connection
-                .dgram_max_writable_len()
-                .map(|maximum| maximum.saturating_sub(datagram_overhead))
-                .unwrap_or_default();
-            match connection.dgram_send(&datagram) {
-                Ok(()) => {
-                    if let Some(packet) = pending_packet.take() {
-                        let _ = packet.completion.send(Ok(()));
-                    }
-                }
-                Err(quiche::Error::Done) => {}
-                Err(quiche::Error::BufferTooShort) => {
-                    if let Some(packet) = pending_packet.take() {
-                        let _ = packet.completion.send(Err(DatagramSendFailure::TooLarge {
-                            maximum_packet_size,
-                        }));
-                    }
-                }
-                Err(error) => {
-                    return Err(TransportError::Http3(format!(
-                        "queue CONNECT-IP datagram: {error:?}"
-                    )));
-                }
-            }
+        if ready && let Some(stream_id) = request_stream_id {
+            queue_pending_batch(&mut connection, stream_id, &mut pending_batch)?;
         }
 
-        generate_wire_datagrams(&mut connection, &mut wire_datagrams, &mut free_wire_buffers)?;
-        send_due_wire_datagrams(&socket, &mut wire_datagrams, &mut free_wire_buffers).await?;
+        let send_quantum = connection.send_quantum();
+        generate_wire_datagrams(
+            &mut connection,
+            &mut wire_datagrams,
+            &mut free_wire_buffers,
+            send_quantum,
+        )?;
 
         if connection.is_closed() {
             return Err(connection_closed_error(&connection));
@@ -556,30 +584,55 @@ async fn drive_h3_actor(
             .front()
             .map(|datagram| Instant::from_std(datagram.send_info.at))
             .unwrap_or_else(|| Instant::now() + Duration::from_secs(86_400));
+        let wire_is_due = wire_datagrams
+            .front()
+            .is_some_and(|datagram| datagram.send_info.at <= StdInstant::now());
 
         tokio::select! {
             received = socket.recv_from(&mut receive_buffer) => {
                 let (length, from) = received?;
-                let info = quiche::RecvInfo {
+                let dropped = receive_quic_datagram(
+                    &mut connection,
+                    &mut receive_buffer[..length],
                     from,
-                    to: local_address,
-                };
-                match connection.recv(&mut receive_buffer[..length], info) {
-                    Ok(_) | Err(quiche::Error::Done) => {}
-                    Err(error) => {
-                        return Err(TransportError::Http3(format!(
-                            "receive QUIC packet: {error:?}"
-                        )));
+                    local_address,
+                )?;
+                record_inbound_queue_drops(dropped, &mut inbound_queue_drop_count);
+                for _ in 1..MAX_SOCKET_DRAIN {
+                    match socket.try_recv_from(&mut receive_buffer) {
+                        Ok((length, from)) => {
+                            let dropped = receive_quic_datagram(
+                                &mut connection,
+                                &mut receive_buffer[..length],
+                                from,
+                                local_address,
+                            )?;
+                            record_inbound_queue_drops(
+                                dropped,
+                                &mut inbound_queue_drop_count,
+                            );
+                        }
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                        Err(error) => return Err(error.into()),
                     }
                 }
             }
-            packet = outgoing_rx.recv(), if ready && pending_packet.is_none() => {
-                match packet {
-                    Some(packet) => pending_packet = Some(packet),
+            batch = outgoing_rx.recv(), if ready && pending_batch.is_none() => {
+                match batch {
+                    Some(batch) => pending_batch = Some(batch),
                     None => return Ok(()),
                 }
             }
-            _ = sleep_until(wire_deadline), if !wire_datagrams.is_empty() => {}
+            writable = socket.writable(), if wire_is_due => {
+                writable?;
+                send_due_wire_datagrams(
+                    &socket,
+                    &mut wire_datagrams,
+                    &mut free_wire_buffers,
+                    send_quantum,
+                )?;
+            }
+            _ = sleep_until(wire_deadline), if !wire_datagrams.is_empty() && !wire_is_due => {}
             _ = sleep_until(quic_deadline) => connection.on_timeout(),
             _ = keepalive.tick(), if connection.is_established() => {
                 connection
@@ -731,13 +784,22 @@ fn drain_received_datagrams(
     connection: &mut quiche::Connection,
     request_stream_id: u64,
     ready: bool,
-    incoming_tx: &mpsc::Sender<Bytes>,
-    buffer: &mut [u8],
-    dropped_packets: &mut u64,
+    incoming_tx: &mpsc::Sender<PacketBatch>,
+    incoming_batch: &mut PacketBatch,
 ) -> Result<(), TransportError> {
-    loop {
-        let length = match connection.dgram_recv(buffer) {
-            Ok(length) => length,
+    if ready && !flush_incoming_batch(incoming_tx, incoming_batch)? {
+        return Ok(());
+    }
+    while let Some(front_len) = connection.dgram_recv_front_len() {
+        if ready
+            && !incoming_batch.is_empty()
+            && !incoming_batch.can_accept(front_len)
+            && !flush_incoming_batch(incoming_tx, incoming_batch)?
+        {
+            break;
+        }
+        let datagram = match connection.dgram_recv_buf() {
+            Ok(datagram) => datagram,
             Err(quiche::Error::Done) => break,
             Err(error) => {
                 return Err(TransportError::Http3(format!(
@@ -748,28 +810,143 @@ fn drain_received_datagrams(
         if !ready {
             continue;
         }
-        let Some(packet) = decode_http_datagram(request_stream_id, &buffer[..length])? else {
+        let Some(packet) = decode_http_datagram_bytes(request_stream_id, Bytes::from(datagram))?
+        else {
             continue;
         };
-        match incoming_tx.try_send(packet) {
-            Ok(()) => {}
-            Err(TrySendError::Full(_)) => {
-                *dropped_packets = dropped_packets.saturating_add(1);
-                if should_log_inbound_drop(*dropped_packets) {
-                    tracing::warn!(
-                        dropped_packets = *dropped_packets,
-                        "dropping inbound H3 packets because the netstack is congested"
-                    );
-                }
+        if let Err(packet) = incoming_batch.push_back(packet) {
+            if !flush_incoming_batch(incoming_tx, incoming_batch)? {
+                return Err(TransportError::Http3(
+                    "incoming batch capacity accounting failed".to_owned(),
+                ));
             }
-            Err(TrySendError::Closed(_)) => return Ok(()),
+            incoming_batch.push_back(packet).map_err(|_| {
+                TransportError::Http3("an inbound datagram exceeded the batch bound".to_owned())
+            })?;
         }
+    }
+    if ready {
+        let _ = flush_incoming_batch(incoming_tx, incoming_batch)?;
     }
     Ok(())
 }
 
-fn should_log_inbound_drop(dropped_packets: u64) -> bool {
-    dropped_packets.is_power_of_two()
+fn flush_incoming_batch(
+    incoming_tx: &mpsc::Sender<PacketBatch>,
+    incoming_batch: &mut PacketBatch,
+) -> Result<bool, TransportError> {
+    if incoming_batch.is_empty() {
+        return Ok(true);
+    }
+    match incoming_tx.try_send(std::mem::take(incoming_batch)) {
+        Ok(()) => Ok(true),
+        Err(TrySendError::Full(batch)) => {
+            *incoming_batch = batch;
+            Ok(false)
+        }
+        Err(TrySendError::Closed(_)) => Err(TransportError::TunnelClosed),
+    }
+}
+
+fn queue_pending_batch(
+    connection: &mut quiche::Connection,
+    stream_id: u64,
+    pending_batch: &mut Option<OutgoingBatch>,
+) -> Result<(), TransportError> {
+    let completed = {
+        let Some(outgoing) = pending_batch.as_mut() else {
+            return Ok(());
+        };
+        for _ in 0..MAX_SOCKET_DRAIN {
+            if connection.is_dgram_send_queue_full() {
+                break;
+            }
+            let Some(packet) = outgoing.batch.front() else {
+                break;
+            };
+            let packet_len = packet.len();
+            let datagram = encode_http_datagram(stream_id, packet)?;
+            let datagram_overhead = datagram.len().saturating_sub(packet_len);
+            let maximum_packet_size = connection
+                .dgram_max_writable_len()
+                .map(|maximum| maximum.saturating_sub(datagram_overhead))
+                .unwrap_or_default();
+            match connection.dgram_send_buf(datagram) {
+                Ok(()) => {
+                    let packet = outgoing
+                        .batch
+                        .pop_front()
+                        .expect("front packet remains until DATAGRAM is accepted");
+                    outgoing.result.accepted_bytes =
+                        outgoing.result.accepted_bytes.saturating_add(packet.len());
+                }
+                Err(quiche::Error::Done) => break,
+                Err(quiche::Error::BufferTooShort) => {
+                    let packet = outgoing
+                        .batch
+                        .pop_front()
+                        .expect("front packet remains until DATAGRAM is rejected");
+                    outgoing
+                        .result
+                        .oversized
+                        .push((packet, maximum_packet_size));
+                }
+                Err(error) => {
+                    return Err(TransportError::Http3(format!(
+                        "queue CONNECT-IP datagram: {error:?}"
+                    )));
+                }
+            }
+        }
+        outgoing.batch.is_empty()
+    };
+    if completed {
+        let outgoing = pending_batch
+            .take()
+            .expect("completed outgoing batch remains present");
+        let _ = outgoing.completion.send(outgoing.result);
+    }
+    Ok(())
+}
+
+fn receive_quic_datagram(
+    connection: &mut quiche::Connection,
+    datagram: &mut [u8],
+    from: SocketAddr,
+    to: SocketAddr,
+) -> Result<usize, TransportError> {
+    let queued_before = connection.dgram_recv_queue_len();
+    let received_before = connection.stats().dgram_recv;
+    let info = quiche::RecvInfo { from, to };
+    match connection.recv(datagram, info) {
+        Ok(_) | Err(quiche::Error::Done) => {
+            let received = connection
+                .stats()
+                .dgram_recv
+                .saturating_sub(received_before);
+            Ok(inbound_queue_overflow(queued_before, received))
+        }
+        Err(error) => Err(TransportError::Http3(format!(
+            "receive QUIC packet: {error:?}"
+        ))),
+    }
+}
+
+fn inbound_queue_overflow(queued_before: usize, received: usize) -> usize {
+    received.saturating_sub(DATAGRAM_RECV_QUEUE_CAPACITY.saturating_sub(queued_before))
+}
+
+fn record_inbound_queue_drops(dropped: usize, total: &mut u64) {
+    for _ in 0..dropped {
+        *total = total.saturating_add(1);
+        if total.is_power_of_two() {
+            tracing::warn!(
+                dropped_datagrams = *total,
+                queue_capacity = DATAGRAM_RECV_QUEUE_CAPACITY,
+                "dropped inbound CONNECT-IP payload after the bounded queue saturated"
+            );
+        }
+    }
 }
 
 struct WireDatagram {
@@ -781,11 +958,19 @@ fn generate_wire_datagrams(
     connection: &mut quiche::Connection,
     pending: &mut VecDeque<WireDatagram>,
     free_buffers: &mut Vec<Vec<u8>>,
+    send_quantum: usize,
 ) -> Result<(), TransportError> {
-    while pending.len() < MAX_PENDING_WIRE_DATAGRAMS {
+    if send_quantum < MAX_UDP_PAYLOAD_SIZE {
+        return Ok(());
+    }
+    let mut generated_bytes = 0usize;
+    while pending.len() < MAX_PENDING_WIRE_DATAGRAMS
+        && generated_bytes.saturating_add(MAX_UDP_PAYLOAD_SIZE) <= send_quantum
+    {
         let mut bytes = take_wire_buffer(free_buffers);
         match connection.send(&mut bytes) {
             Ok((length, send_info)) => {
+                generated_bytes = generated_bytes.saturating_add(length);
                 bytes.truncate(length);
                 pending.push_back(WireDatagram { bytes, send_info });
             }
@@ -803,29 +988,47 @@ fn generate_wire_datagrams(
     Ok(())
 }
 
-async fn send_due_wire_datagrams(
+fn send_due_wire_datagrams(
     socket: &UdpSocket,
     pending: &mut VecDeque<WireDatagram>,
     free_buffers: &mut Vec<Vec<u8>>,
+    send_quantum: usize,
 ) -> Result<(), TransportError> {
-    while pending
+    if !pending
         .front()
         .is_some_and(|datagram| datagram.send_info.at <= StdInstant::now())
     {
-        let datagram = pending
-            .pop_front()
-            .expect("front exists while draining due QUIC packets");
-        let sent = socket
-            .send_to(&datagram.bytes, datagram.send_info.to)
-            .await?;
-        if sent != datagram.bytes.len() {
-            return Err(io::Error::new(
-                io::ErrorKind::WriteZero,
-                "UDP socket sent a partial QUIC datagram",
-            )
-            .into());
+        return Ok(());
+    }
+    let mut sent_bytes = 0usize;
+    for _ in 0..MAX_SOCKET_DRAIN {
+        let Some(datagram) = pending.front() else {
+            break;
+        };
+        if datagram.send_info.at > StdInstant::now() {
+            break;
         }
-        recycle_wire_buffer(free_buffers, datagram.bytes);
+        if sent_bytes.saturating_add(datagram.bytes.len()) > send_quantum {
+            break;
+        }
+        match socket.try_send_to(&datagram.bytes, datagram.send_info.to) {
+            Ok(sent) if sent == datagram.bytes.len() => {
+                sent_bytes = sent_bytes.saturating_add(sent);
+                let datagram = pending
+                    .pop_front()
+                    .expect("front exists after successful QUIC send");
+                recycle_wire_buffer(free_buffers, datagram.bytes);
+            }
+            Ok(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "UDP socket sent a partial QUIC datagram",
+                )
+                .into());
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+            Err(error) => return Err(error.into()),
+        }
     }
     Ok(())
 }
@@ -854,11 +1057,11 @@ fn encode_http_datagram(stream_id: u64, packet: &[u8]) -> Result<Vec<u8>, Transp
     Ok(encoded)
 }
 
-fn decode_http_datagram(
+fn decode_http_datagram_bytes(
     request_stream_id: u64,
-    datagram: &[u8],
+    datagram: Bytes,
 ) -> Result<Option<Bytes>, TransportError> {
-    let Some((quarter_stream_id, stream_bytes)) = decode_varint(datagram)? else {
+    let Some((quarter_stream_id, stream_bytes)) = decode_varint(&datagram)? else {
         return Err(TransportError::MalformedIpPacket);
     };
     if quarter_stream_id != request_stream_id / 4 {
@@ -867,12 +1070,20 @@ fn decode_http_datagram(
     let payload = datagram
         .get(stream_bytes..)
         .ok_or(TransportError::MalformedIpPacket)?;
-    let datagram = IpDatagram::decode(Bytes::copy_from_slice(payload))?;
+    let datagram = IpDatagram::decode(datagram.slice(stream_bytes..stream_bytes + payload.len()))?;
     if datagram.context_id != usque_protocol::DEFAULT_CONTEXT_ID {
         return Ok(None);
     }
     validate_ip_packet(&datagram.packet)?;
     Ok(Some(datagram.packet))
+}
+
+#[cfg(test)]
+fn decode_http_datagram(
+    request_stream_id: u64,
+    datagram: &[u8],
+) -> Result<Option<Bytes>, TransportError> {
+    decode_http_datagram_bytes(request_stream_id, Bytes::copy_from_slice(datagram))
 }
 
 fn decode_varint(buffer: &[u8]) -> Result<Option<(u64, usize)>, TransportError> {
@@ -941,10 +1152,43 @@ fn connection_closed_error(connection: &quiche::Connection) -> TransportError {
 mod tests {
     use super::*;
 
+    struct DropSignal(Option<oneshot::Sender<()>>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
     fn ipv4_packet() -> [u8; 20] {
         [
             0x45, 0, 0, 20, 0, 0, 0, 0, 64, 17, 0, 0, 1, 1, 1, 1, 8, 8, 8, 8,
         ]
+    }
+
+    #[tokio::test]
+    async fn dropping_driver_wait_aborts_the_old_actor() {
+        let (started_tx, started_rx) = oneshot::channel();
+        let (dropped_tx, dropped_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _drop_signal = DropSignal(Some(dropped_tx));
+            let _ = started_tx.send(());
+            std::future::pending::<Result<(), TransportError>>().await
+        });
+        started_rx.await.unwrap();
+        let driver = H3Driver { task: Some(task) };
+        let mut wait = Box::pin(driver.wait());
+        tokio::select! {
+            result = &mut wait => panic!("driver wait completed early: {result:?}"),
+            () = tokio::time::sleep(Duration::from_millis(10)) => {}
+        }
+        drop(wait);
+        timeout(Duration::from_secs(1), dropped_rx)
+            .await
+            .expect("dropping the wait future did not abort the old actor")
+            .unwrap();
     }
 
     #[test]
@@ -986,6 +1230,48 @@ mod tests {
     }
 
     #[test]
+    fn owned_http_datagram_decode_reuses_the_receive_allocation() {
+        let packet = ipv4_packet();
+        let encoded = encode_http_datagram(8, &packet).unwrap();
+        let allocation = encoded.as_ptr() as usize;
+        let (_, stream_prefix) = decode_varint(&encoded).unwrap().unwrap();
+        let (_, context_prefix) = decode_varint(&encoded[stream_prefix..]).unwrap().unwrap();
+        let expected_payload = allocation + stream_prefix + context_prefix;
+
+        let decoded = decode_http_datagram_bytes(8, Bytes::from(encoded))
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded.as_ptr() as usize, expected_payload);
+        assert_eq!(decoded.as_ref(), packet);
+    }
+
+    #[test]
+    fn inbound_queue_overflow_counts_only_payloads_beyond_the_bound() {
+        assert_eq!(inbound_queue_overflow(0, DATAGRAM_RECV_QUEUE_CAPACITY), 0);
+        assert_eq!(
+            inbound_queue_overflow(DATAGRAM_RECV_QUEUE_CAPACITY - 1, 1),
+            0
+        );
+        assert_eq!(
+            inbound_queue_overflow(DATAGRAM_RECV_QUEUE_CAPACITY - 1, 3),
+            2
+        );
+        assert_eq!(inbound_queue_overflow(DATAGRAM_RECV_QUEUE_CAPACITY, 4), 4);
+    }
+
+    #[test]
+    fn inbound_batch_storage_is_bounded_to_1024_packets() {
+        let application_channel = INCOMING_BATCH_CHANNEL_CAPACITY * MAX_PACKET_BATCH_PACKETS;
+        assert_eq!(
+            application_channel
+                + MAX_PACKET_BATCH_PACKETS // receive-half pending batch
+                + MAX_PACKET_BATCH_PACKETS // actor pending batch
+                + DATAGRAM_RECV_QUEUE_CAPACITY,
+            INBOUND_PACKET_CAPACITY
+        );
+    }
+
+    #[test]
     fn wire_datagram_buffers_are_reused_with_a_fixed_bound() {
         let mut free = Vec::new();
         let first = take_wire_buffer(&mut free);
@@ -1004,12 +1290,71 @@ mod tests {
         assert_eq!(free.len(), MAX_PENDING_WIRE_DATAGRAMS);
     }
 
-    #[test]
-    fn inbound_congestion_warnings_are_exponentially_rate_limited() {
-        let logged = (0..=17)
-            .filter(|count| should_log_inbound_drop(*count))
-            .collect::<Vec<_>>();
-        assert_eq!(logged, vec![1, 2, 4, 8, 16]);
+    #[tokio::test]
+    async fn udp_send_drain_respects_send_quantum_and_pacing_deadline() {
+        let receiver = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let from = sender.local_addr().unwrap();
+        let to = receiver.local_addr().unwrap();
+        let due = StdInstant::now();
+        let future = due + Duration::from_secs(60);
+        let mut pending = VecDeque::from([
+            WireDatagram {
+                bytes: vec![1; 100],
+                send_info: quiche::SendInfo { from, to, at: due },
+            },
+            WireDatagram {
+                bytes: vec![2; 100],
+                send_info: quiche::SendInfo { from, to, at: due },
+            },
+            WireDatagram {
+                bytes: vec![3; 100],
+                send_info: quiche::SendInfo {
+                    from,
+                    to,
+                    at: future,
+                },
+            },
+        ]);
+        let mut free = Vec::new();
+
+        sender.writable().await.unwrap();
+        send_due_wire_datagrams(&sender, &mut pending, &mut free, 150).unwrap();
+        assert_eq!(pending.len(), 2);
+        let mut received = [0u8; 128];
+        let length = timeout(Duration::from_secs(1), receiver.recv(&mut received))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(&received[..length], &[1; 100]);
+
+        sender.writable().await.unwrap();
+        send_due_wire_datagrams(&sender, &mut pending, &mut free, 500).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending.front().unwrap().bytes, vec![3; 100]);
+    }
+
+    #[tokio::test]
+    async fn inbound_batch_is_retained_until_channel_capacity_returns() {
+        let (incoming_tx, mut incoming_rx) = mpsc::channel(1);
+        incoming_tx
+            .try_send(PacketBatch::single(Bytes::from_static(b"queued")))
+            .unwrap();
+        let mut pending = PacketBatch::single(Bytes::from_static(b"pending"));
+
+        assert!(!flush_incoming_batch(&incoming_tx, &mut pending).unwrap());
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            incoming_rx.recv().await.unwrap().pop_front().unwrap(),
+            Bytes::from_static(b"queued")
+        );
+
+        assert!(flush_incoming_batch(&incoming_tx, &mut pending).unwrap());
+        assert!(pending.is_empty());
+        assert_eq!(
+            incoming_rx.recv().await.unwrap().pop_front().unwrap(),
+            Bytes::from_static(b"pending")
+        );
     }
 
     #[test]

--- a/crates/usque-transport/src/lib.rs
+++ b/crates/usque-transport/src/lib.rs
@@ -14,6 +14,7 @@ mod http_proxy;
 mod icmp;
 mod masque_runtime;
 mod netstack;
+mod packet_batch;
 mod packet_mux;
 mod pin_refresh;
 mod port_allocator;

--- a/crates/usque-transport/src/masque_runtime.rs
+++ b/crates/usque-transport/src/masque_runtime.rs
@@ -17,6 +17,7 @@ use crate::netstack::{
     ManagedTunnelMonitor, ManagedTunnelRuntime, PacketStack, ProxyPerformanceSnapshot,
     RuntimeHealth, RuntimePath, TrafficSnapshot,
 };
+use crate::packet_batch::{PACKET_BATCH_CHANNEL_CAPACITY, PacketBatch};
 use crate::packet_mux::{PacketMuxTable, PacketOrigin};
 use crate::pin_refresh::EndpointPinRefresher;
 use crate::socket::{SocketProtector, noop_socket_protector};
@@ -31,31 +32,46 @@ const PACKET_QUEUE_CAPACITY: usize = 1_024;
 /// TUN-origin packets are discarded until [`MasqueRuntime::attach_tun`].
 pub struct MasqueTunIo {
     outgoing: mpsc::Sender<Bytes>,
-    incoming: mpsc::Receiver<Bytes>,
+    incoming: mpsc::Receiver<PacketBatch>,
+    pending_incoming: PacketBatch,
 }
 
 impl MasqueTunIo {
     pub async fn send_packet(&self, packet: &[u8]) -> Result<(), TransportError> {
         crate::h2::validate_ip_packet(packet)?;
-        match self.outgoing.try_send(Bytes::copy_from_slice(packet)) {
-            Ok(()) => Ok(()),
-            Err(mpsc::error::TrySendError::Full(_)) => Err(TransportError::SendQueueFull),
-            Err(mpsc::error::TrySendError::Closed(_)) => Err(TransportError::TunnelClosed),
-        }
+        let permit = self
+            .outgoing
+            .reserve()
+            .await
+            .map_err(|_| TransportError::TunnelClosed)?;
+        permit.send(Bytes::copy_from_slice(packet));
+        Ok(())
     }
 
     pub async fn receive_packet(&mut self) -> Result<Bytes, TransportError> {
-        self.incoming
-            .recv()
-            .await
-            .ok_or(TransportError::TunnelClosed)
+        loop {
+            if let Some(packet) = self.pending_incoming.pop_front() {
+                return Ok(packet);
+            }
+            self.pending_incoming = self
+                .incoming
+                .recv()
+                .await
+                .ok_or(TransportError::TunnelClosed)?;
+        }
     }
 
     /// Receives an already queued packet without waiting. This lets platform
     /// packet pumps publish a bounded batch under one kernel wakeup.
     pub fn try_receive_packet(&mut self) -> Result<Option<Bytes>, TransportError> {
+        if let Some(packet) = self.pending_incoming.pop_front() {
+            return Ok(Some(packet));
+        }
         match self.incoming.try_recv() {
-            Ok(packet) => Ok(Some(packet)),
+            Ok(batch) => {
+                self.pending_incoming = batch;
+                Ok(self.pending_incoming.pop_front())
+            }
             Err(mpsc::error::TryRecvError::Empty) => Ok(None),
             Err(mpsc::error::TryRecvError::Disconnected) => Err(TransportError::TunnelClosed),
         }
@@ -73,8 +89,8 @@ pub struct MasqueRuntime {
     http_spec: Option<FrontendSpec>,
     listeners: Vec<SocketAddr>,
     raw_outgoing: Option<mpsc::Sender<Bytes>>,
-    tun_sink: watch::Sender<Option<mpsc::Sender<Bytes>>>,
-    _tun_sink_rx: watch::Receiver<Option<mpsc::Sender<Bytes>>>,
+    tun_sink: watch::Sender<Option<mpsc::Sender<PacketBatch>>>,
+    _tun_sink_rx: watch::Receiver<Option<mpsc::Sender<PacketBatch>>>,
     cancellation: CancellationToken,
     mux_task: Option<JoinHandle<()>>,
     assigned_ipv4: Ipv4Addr,
@@ -430,9 +446,13 @@ impl MasqueRuntime {
             .raw_outgoing
             .clone()
             .ok_or(TransportError::TunnelClosed)?;
-        let (incoming_tx, incoming) = mpsc::channel(PACKET_QUEUE_CAPACITY);
+        let (incoming_tx, incoming) = mpsc::channel(PACKET_BATCH_CHANNEL_CAPACITY);
         self.tun_sink.send_replace(Some(incoming_tx));
-        Ok(MasqueTunIo { outgoing, incoming })
+        Ok(MasqueTunIo {
+            outgoing,
+            incoming,
+            pending_incoming: PacketBatch::new(),
+        })
     }
 
     /// Stop delivering TUN-origin packets. SOCKS/HTTP and MASQUE stay up.
@@ -442,14 +462,15 @@ impl MasqueRuntime {
 
     pub async fn send_packet(&self, packet: &[u8]) -> Result<(), TransportError> {
         crate::h2::validate_ip_packet(packet)?;
-        self.raw_outgoing
+        let permit = self
+            .raw_outgoing
             .as_ref()
             .ok_or(TransportError::TunnelClosed)?
-            .try_send(Bytes::copy_from_slice(packet))
-            .map_err(|error| match error {
-                mpsc::error::TrySendError::Full(_) => TransportError::SendQueueFull,
-                mpsc::error::TrySendError::Closed(_) => TransportError::TunnelClosed,
-            })
+            .reserve()
+            .await
+            .map_err(|_| TransportError::TunnelClosed)?;
+        permit.send(Bytes::copy_from_slice(packet));
+        Ok(())
     }
 
     pub fn assigned_ipv4(&self) -> Ipv4Addr {
@@ -549,7 +570,7 @@ async fn run_packet_mux(
     proxy_pipe: WakingPipe,
     mut raw_outgoing: mpsc::Receiver<Bytes>,
     direct_gateway: DirectGatewayMux,
-    tun_sink: watch::Sender<Option<mpsc::Sender<Bytes>>>,
+    tun_sink: watch::Sender<Option<mpsc::Sender<PacketBatch>>>,
     cancellation: &CancellationToken,
 ) {
     let DirectGatewayMux {
@@ -566,6 +587,8 @@ async fn run_packet_mux(
     };
     let mut flows = PacketMuxTable::default();
     let mut direct_incoming_open = true;
+    let mut tun_dropped_batches = 0u64;
+    let mut tun_dropped_packets = 0u64;
 
     loop {
         // Tokio randomizes ready branch order, so the two ingress queues get
@@ -583,10 +606,14 @@ async fn run_packet_mux(
                 }
                 // DirectGatewayRouter guarantees that a false result leaves
                 // the packet unchanged, so the earlier parse remains valid.
-                if flows.route_inspected_outgoing(&mut packet, inspection)
-                    && sender.send_owned_packet(packet.freeze()).await.is_err()
-                {
-                    break;
+                if flows.route_inspected_outgoing(&mut packet, inspection) {
+                    match sender.send_owned_packet(packet.freeze()).await {
+                        Ok(()) => {}
+                        Err(TransportError::TunnelClosed) => break,
+                        Err(error) => {
+                            tracing::warn!(%error, "discarded a TUN packet rejected by the MASQUE sender");
+                        }
+                    }
                 }
             }
             packet = rx.recv_async() => {
@@ -594,28 +621,54 @@ async fn run_packet_mux(
                 let mut packet = packet
                     .try_into_mut()
                     .unwrap_or_else(|packet| bytes::BytesMut::from(packet.as_ref()));
-                if flows.route_outgoing(PacketOrigin::Proxy, &mut packet)
-                    && sender.send_owned_packet(packet.freeze()).await.is_err()
-                {
-                    break;
+                if flows.route_outgoing(PacketOrigin::Proxy, &mut packet) {
+                    match sender.send_owned_packet(packet.freeze()).await {
+                        Ok(()) => {}
+                        Err(TransportError::TunnelClosed) => break,
+                        Err(error) => {
+                            tracing::warn!(%error, "discarded a proxy packet rejected by the MASQUE sender");
+                        }
+                    }
                 }
             }
-            packet = tunnel.receive_packet() => {
-                let Ok(packet) = packet else { break; };
-                let mut packet = packet
-                    .try_into_mut()
-                    .unwrap_or_else(|packet| bytes::BytesMut::from(packet.as_ref()));
-                match flows.route_incoming(&mut packet) {
-                    Some(PacketOrigin::Tunnel) => {
-                        dispatch_tun_incoming(&tun_sink, packet.freeze());
+            batch = tunnel.receive_batch() => {
+                let Ok(mut batch) = batch else { break; };
+                let mut tun_batch = PacketBatch::new();
+                while let Some(packet) = batch.pop_front() {
+                    let mut packet = packet
+                        .try_into_mut()
+                        .unwrap_or_else(|packet| bytes::BytesMut::from(packet.as_ref()));
+                    match flows.route_incoming(&mut packet) {
+                        Some(PacketOrigin::Tunnel) => {
+                            let packet = packet.freeze();
+                            if let Err(packet) = tun_batch.push_back(packet) {
+                                record_tun_sink_drop(
+                                    dispatch_tun_incoming_batch(&tun_sink, std::mem::take(&mut tun_batch)),
+                                    &mut tun_dropped_batches,
+                                    &mut tun_dropped_packets,
+                                );
+                                tun_batch
+                                    .push_back(packet)
+                                    .expect("one valid packet fits an empty TUN batch");
+                            }
+                        }
+                        Some(PacketOrigin::Proxy) => proxy_incoming.send_async(&packet).await,
+                        None => tracing::debug!("dropped an unattributed MASQUE return packet"),
                     }
-                    Some(PacketOrigin::Proxy) => proxy_incoming.send_async(&packet).await,
-                    None => tracing::debug!("dropped an unattributed MASQUE return packet"),
                 }
+                record_tun_sink_drop(
+                    dispatch_tun_incoming_batch(&tun_sink, tun_batch),
+                    &mut tun_dropped_batches,
+                    &mut tun_dropped_packets,
+                );
             }
             packet = incoming.recv(), if direct_incoming_open => {
                 match packet {
-                    Some(packet) => dispatch_tun_incoming(&tun_sink, packet),
+                    Some(packet) => record_tun_sink_drop(
+                        dispatch_tun_incoming(&tun_sink, packet),
+                        &mut tun_dropped_batches,
+                        &mut tun_dropped_packets,
+                    ),
                     None => direct_incoming_open = false,
                 }
             }
@@ -632,17 +685,46 @@ struct DirectGatewayMux {
 ///
 /// A closed or full TUN sink must not tear the MASQUE mux: SOCKS/HTTP still
 /// need the session.
-fn dispatch_tun_incoming(tun_sink: &watch::Sender<Option<mpsc::Sender<Bytes>>>, packet: Bytes) {
+fn dispatch_tun_incoming(
+    tun_sink: &watch::Sender<Option<mpsc::Sender<PacketBatch>>>,
+    packet: Bytes,
+) -> usize {
+    dispatch_tun_incoming_batch(tun_sink, PacketBatch::single(packet))
+}
+
+fn dispatch_tun_incoming_batch(
+    tun_sink: &watch::Sender<Option<mpsc::Sender<PacketBatch>>>,
+    batch: PacketBatch,
+) -> usize {
+    if batch.is_empty() {
+        return 0;
+    }
     let sink = tun_sink.borrow().clone();
     let Some(sink) = sink else {
-        return;
+        return 0;
     };
-    match sink.try_send(packet) {
-        Ok(()) => {}
-        Err(mpsc::error::TrySendError::Full(_)) => {}
+    match sink.try_send(batch) {
+        Ok(()) => 0,
+        Err(mpsc::error::TrySendError::Full(batch)) => batch.len(),
         Err(mpsc::error::TrySendError::Closed(_)) => {
             tun_sink.send_replace(None);
+            0
         }
+    }
+}
+
+fn record_tun_sink_drop(dropped: usize, batches: &mut u64, packets: &mut u64) {
+    if dropped == 0 {
+        return;
+    }
+    *batches = batches.saturating_add(1);
+    *packets = packets.saturating_add(dropped as u64);
+    if batches.is_power_of_two() {
+        tracing::warn!(
+            dropped_batches = *batches,
+            dropped_packets = *packets,
+            "dropping inbound TUN batches because the platform packet pump is congested"
+        );
     }
 }
 
@@ -734,8 +816,31 @@ mod tests {
     use std::sync::{Mutex, OnceLock};
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::time::timeout;
     use usque_core::FrontendSettings;
     use zeroize::Zeroizing;
+
+    fn mux_udp_packet(source_port: u16) -> Bytes {
+        let mut packet = vec![0u8; 28];
+        packet[0] = 0x45;
+        packet[2..4].copy_from_slice(&28_u16.to_be_bytes());
+        packet[8] = 64;
+        packet[9] = 17;
+        packet[12..16].copy_from_slice(&[172, 16, 0, 2]);
+        packet[16..20].copy_from_slice(&[198, 51, 100, 1]);
+        packet[20..22].copy_from_slice(&source_port.to_be_bytes());
+        packet[22..24].copy_from_slice(&443_u16.to_be_bytes());
+        packet[24..26].copy_from_slice(&8_u16.to_be_bytes());
+        let mut sum = 0u32;
+        for word in packet[..20].chunks_exact(2) {
+            sum += u32::from(u16::from_be_bytes([word[0], word[1]]));
+        }
+        while sum > 0xffff {
+            sum = (sum & 0xffff) + (sum >> 16);
+        }
+        packet[10..12].copy_from_slice(&(!(sum as u16)).to_be_bytes());
+        Bytes::from(packet)
+    }
 
     #[test]
     fn frontend_spec_includes_auth_dns_and_idle() {
@@ -933,44 +1038,235 @@ mod tests {
         let (tun_sink, _rx) = watch::channel(None);
         let (tx, mut rx) = mpsc::channel(4);
         tun_sink.send_replace(Some(tx.clone()));
-        dispatch_tun_incoming(&tun_sink, Bytes::from_static(b"keep"));
-        assert_eq!(rx.recv().await.unwrap(), Bytes::from_static(b"keep"));
+        assert_eq!(
+            dispatch_tun_incoming(&tun_sink, Bytes::from_static(b"keep")),
+            0
+        );
+        assert_eq!(
+            rx.recv().await.unwrap().pop_front().unwrap(),
+            Bytes::from_static(b"keep")
+        );
 
         tun_sink.send_replace(None);
-        dispatch_tun_incoming(&tun_sink, Bytes::from_static(b"drop"));
+        assert_eq!(
+            dispatch_tun_incoming(&tun_sink, Bytes::from_static(b"drop")),
+            0
+        );
         assert!(rx.try_recv().is_err());
         assert!(tun_sink.borrow().is_none());
 
         drop(rx);
         tun_sink.send_replace(Some(tx));
-        dispatch_tun_incoming(&tun_sink, Bytes::from_static(b"closed"));
+        assert_eq!(
+            dispatch_tun_incoming(&tun_sink, Bytes::from_static(b"closed")),
+            0
+        );
         assert!(tun_sink.borrow().is_none());
     }
 
     #[tokio::test]
-    async fn tun_send_queue_saturation_fails_immediately() {
-        let (outgoing, _outgoing_rx) = mpsc::channel(1);
+    async fn saturated_tun_sink_drops_only_payload_and_recovers() {
+        let (tun_sink, _watch) = watch::channel(None);
+        let (tx, mut rx) = mpsc::channel(1);
+        tun_sink.send_replace(Some(tx));
+        assert_eq!(
+            dispatch_tun_incoming(&tun_sink, Bytes::from_static(b"first")),
+            0
+        );
+        assert_eq!(
+            dispatch_tun_incoming(&tun_sink, Bytes::from_static(b"overflow")),
+            1
+        );
+        assert!(tun_sink.borrow().is_some());
+        assert_eq!(
+            rx.recv().await.unwrap().pop_front().unwrap(),
+            Bytes::from_static(b"first")
+        );
+        assert_eq!(
+            dispatch_tun_incoming(&tun_sink, Bytes::from_static(b"recovered")),
+            0
+        );
+        assert_eq!(
+            rx.recv().await.unwrap().pop_front().unwrap(),
+            Bytes::from_static(b"recovered")
+        );
+    }
+
+    #[tokio::test]
+    async fn packet_mux_survives_inner_backpressure_for_tun_and_proxy_sources() {
+        let (mut tunnel, mut inner_rx, managed_incoming) =
+            ManagedTunnelRuntime::packet_mux_test_channels(1);
+        let (raw_tx, raw_rx) = mpsc::channel(4);
+        let (_tun_incoming_tx, tun_incoming) = mpsc::channel(1);
+        let tun_io = MasqueTunIo {
+            outgoing: raw_tx,
+            incoming: tun_incoming,
+            pending_incoming: PacketBatch::new(),
+        };
+        let (proxy_pipe, proxy_client) = WakingPipe::bounded(4);
+        let WakingPipe {
+            rx: _proxy_responses,
+            tx: proxy_outgoing,
+        } = proxy_client;
+        let cancellation = CancellationToken::new();
+        let (router, direct_incoming) = DirectGatewayRouter::start(
+            &Profile::default(),
+            Arc::new(GeoDirectPolicy::disabled()),
+            noop_socket_protector(),
+            Arc::new(crate::netstack::TrafficCounters::default()),
+            None,
+            &cancellation,
+        )
+        .await
+        .unwrap();
+        let direct_gateway = DirectGatewayMux {
+            router,
+            incoming: direct_incoming,
+        };
+        let (tun_sink, _tun_sink_rx) = watch::channel(None);
+        let task_cancellation = cancellation.clone();
+        let task = tokio::spawn(async move {
+            let _managed_incoming = managed_incoming;
+            run_packet_mux(
+                &mut tunnel,
+                proxy_pipe,
+                raw_rx,
+                direct_gateway,
+                tun_sink,
+                &task_cancellation,
+            )
+            .await;
+        });
+
+        tun_io.send_packet(&mux_udp_packet(50_000)).await.unwrap();
+        tun_io.send_packet(&mux_udp_packet(50_001)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!task.is_finished());
+        let first = timeout(Duration::from_secs(1), inner_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let second = timeout(Duration::from_secs(1), inner_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(u16::from_be_bytes([first[20], first[21]]), 50_000);
+        assert_eq!(u16::from_be_bytes([second[20], second[21]]), 50_001);
+
+        proxy_outgoing.send_async(&mux_udp_packet(50_002)).await;
+        let proxy = timeout(Duration::from_secs(1), inner_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(u16::from_be_bytes([proxy[20], proxy[21]]), 50_002);
+        assert!(!task.is_finished());
+
+        cancellation.cancel();
+        timeout(Duration::from_secs(1), task)
+            .await
+            .expect("packet mux did not stop after cancellation")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn tun_send_queue_saturation_backpressures_and_resumes_in_order() {
+        let (outgoing, mut outgoing_rx) = mpsc::channel(1);
         let (_incoming_tx, incoming) = mpsc::channel(1);
-        let io = MasqueTunIo { outgoing, incoming };
+        let io = MasqueTunIo {
+            outgoing,
+            incoming,
+            pending_incoming: PacketBatch::new(),
+        };
         let packet = [
             0x45, 0, 0, 20, 0, 0, 0, 0, 64, 17, 0, 0, 1, 1, 1, 1, 8, 8, 8, 8,
         ];
 
         io.send_packet(&packet).await.unwrap();
+        let second_send = io.send_packet(&packet);
+        tokio::pin!(second_send);
+        tokio::select! {
+            result = &mut second_send => panic!("saturated send completed early: {result:?}"),
+            () = tokio::time::sleep(Duration::from_millis(10)) => {}
+        }
+
+        assert_eq!(outgoing_rx.recv().await.unwrap().as_ref(), packet);
+        second_send.await.unwrap();
+        assert_eq!(outgoing_rx.recv().await.unwrap().as_ref(), packet);
+    }
+
+    #[tokio::test]
+    async fn closing_tun_send_queue_releases_a_backpressured_sender() {
+        let (outgoing, mut outgoing_rx) = mpsc::channel(1);
+        let (_incoming_tx, incoming) = mpsc::channel(1);
+        let io = MasqueTunIo {
+            outgoing,
+            incoming,
+            pending_incoming: PacketBatch::new(),
+        };
+        let packet = [
+            0x45, 0, 0, 20, 0, 0, 0, 0, 64, 17, 0, 0, 1, 1, 1, 1, 8, 8, 8, 8,
+        ];
+
+        io.send_packet(&packet).await.unwrap();
+        let blocked_send = io.send_packet(&packet);
+        tokio::pin!(blocked_send);
+        tokio::select! {
+            result = &mut blocked_send => panic!("saturated send completed early: {result:?}"),
+            () = tokio::time::sleep(Duration::from_millis(10)) => {}
+        }
+
+        outgoing_rx.close();
         assert!(matches!(
-            io.send_packet(&packet).await,
-            Err(TransportError::SendQueueFull)
+            blocked_send.await,
+            Err(TransportError::TunnelClosed)
         ));
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_a_backpressured_tun_send_without_enqueuing_it() {
+        let (outgoing, mut outgoing_rx) = mpsc::channel(1);
+        let (_incoming_tx, incoming) = mpsc::channel(1);
+        let io = MasqueTunIo {
+            outgoing,
+            incoming,
+            pending_incoming: PacketBatch::new(),
+        };
+        let packet = [
+            0x45, 0, 0, 20, 0, 0, 0, 0, 64, 17, 0, 0, 1, 1, 1, 1, 8, 8, 8, 8,
+        ];
+        io.send_packet(&packet).await.unwrap();
+        let cancellation = CancellationToken::new();
+        let blocked_send = async {
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => None,
+                result = io.send_packet(&packet) => Some(result),
+            }
+        };
+        tokio::pin!(blocked_send);
+        tokio::select! {
+            result = &mut blocked_send => panic!("saturated send completed early: {result:?}"),
+            () = tokio::time::sleep(Duration::from_millis(10)) => {}
+        }
+
+        cancellation.cancel();
+        assert!(blocked_send.await.is_none());
+        assert_eq!(outgoing_rx.recv().await.unwrap().as_ref(), packet);
+        assert!(outgoing_rx.try_recv().is_err());
     }
 
     #[test]
     fn tun_receive_queue_can_be_drained_without_waiting() {
         let (outgoing, _outgoing_rx) = mpsc::channel(1);
         let (incoming_tx, incoming) = mpsc::channel(2);
-        let mut io = MasqueTunIo { outgoing, incoming };
+        let mut io = MasqueTunIo {
+            outgoing,
+            incoming,
+            pending_incoming: PacketBatch::new(),
+        };
 
         incoming_tx
-            .try_send(Bytes::from_static(b"packet"))
+            .try_send(PacketBatch::single(Bytes::from_static(b"packet")))
             .expect("queue packet");
         assert_eq!(
             io.try_receive_packet().expect("queued packet"),

--- a/crates/usque-transport/src/netstack.rs
+++ b/crates/usque-transport/src/netstack.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::future::Future;
 use std::net::IpAddr;
 use std::pin::Pin;
@@ -6,7 +7,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
-use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep, timeout};
@@ -26,13 +26,14 @@ use usque_protocol::{IpAddressRange, IpPrefix, PeerNetworkState};
 use crate::geo_direct::GeoDirectPolicy;
 use crate::h2::{MasqueTlsIdentity, TransportError, connect_h2_with_protector};
 use crate::h3::connect_h3_with_protector;
+use crate::packet_batch::{PACKET_BATCH_CHANNEL_CAPACITY, PacketBatch, PacketBatchResult};
 use crate::pin_refresh::EndpointPinRefresher;
 use crate::socket::SocketProtector;
 use crate::telemetry::{
     ConnectionAttemptTelemetry, ConnectionEventPath, ConnectionEventType, ConnectionTelemetry,
     ConnectionTimelineSnapshot,
 };
-use crate::tunnel::MasqueTunnel;
+use crate::tunnel::{BatchSendFuture, MasqueTunnel};
 
 const HAPPY_EYEBALLS_DELAY: Duration = Duration::from_millis(250);
 const STACK_COMMAND_CAPACITY: usize = 256;
@@ -415,7 +416,8 @@ impl Drop for PacketStack {
 /// them and decrements TTL/hop-limit immediately before encapsulation.
 pub struct ManagedTunnelRuntime {
     outgoing: Option<mpsc::Sender<Bytes>>,
-    incoming: mpsc::Receiver<Bytes>,
+    incoming: mpsc::Receiver<PacketBatch>,
+    pending_incoming: PacketBatch,
     cancellation: CancellationToken,
     failure: watch::Receiver<Option<String>>,
     health: watch::Receiver<RuntimeHealth>,
@@ -458,14 +460,16 @@ impl ManagedTunnelSender {
             .max_capacity()
             .saturating_sub(self.outgoing.capacity());
         self.telemetry.observe_queue_depth(queued);
-        match self.outgoing.try_send(packet) {
-            Ok(()) => Ok(()),
-            Err(TrySendError::Full(_)) => {
-                self.telemetry.record_queue_drop();
-                Err(TransportError::SendQueueFull)
-            }
-            Err(TrySendError::Closed(_)) => Err(TransportError::TunnelClosed),
+        if self.outgoing.capacity() == 0 {
+            self.telemetry.record_queue_saturated(queued);
         }
+        let permit = self
+            .outgoing
+            .reserve()
+            .await
+            .map_err(|_| TransportError::TunnelClosed)?;
+        permit.send(packet);
+        Ok(())
     }
 }
 
@@ -519,6 +523,37 @@ impl ManagedTunnelMonitor {
 }
 
 impl ManagedTunnelRuntime {
+    #[cfg(test)]
+    pub(crate) fn packet_mux_test_channels(
+        outgoing_capacity: usize,
+    ) -> (Self, mpsc::Receiver<Bytes>, mpsc::Sender<PacketBatch>) {
+        let (outgoing, outgoing_rx) = mpsc::channel(outgoing_capacity);
+        let (incoming_tx, incoming) = mpsc::channel(PACKET_BATCH_CHANNEL_CAPACITY);
+        let (_failure_tx, failure) = watch::channel(None);
+        let path = runtime_path(Transport::Http3, AddressFamily::Ipv4);
+        let (_health_tx, health) = watch::channel(RuntimeHealth::Connected {
+            path,
+            reconnect_count: 0,
+        });
+        let (_control_tx, control) = watch::channel(PeerNetworkState::default());
+        (
+            Self {
+                outgoing: Some(outgoing),
+                incoming,
+                pending_incoming: PacketBatch::new(),
+                cancellation: CancellationToken::new(),
+                failure,
+                health,
+                control,
+                counters: Arc::new(TrafficCounters::default()),
+                telemetry: ConnectionTelemetry::default(),
+                tasks: Vec::new(),
+            },
+            outgoing_rx,
+            incoming_tx,
+        )
+    }
+
     pub async fn start(
         profile: &Profile,
         identity: MasqueTlsIdentity,
@@ -554,7 +589,7 @@ impl ManagedTunnelRuntime {
             .await?;
         let path = runtime_path(tunnel.transport(), endpoint_family);
         let (outgoing, outgoing_rx) = mpsc::channel(RAW_PACKET_CHANNEL_CAPACITY);
-        let (incoming_tx, incoming) = mpsc::channel(RAW_PACKET_CHANNEL_CAPACITY);
+        let (incoming_tx, incoming) = mpsc::channel(PACKET_BATCH_CHANNEL_CAPACITY);
         let cancellation = CancellationToken::new();
         let (failure_tx, failure) = watch::channel(None);
         let (health_tx, health) = watch::channel(RuntimeHealth::Connected {
@@ -569,6 +604,7 @@ impl ManagedTunnelRuntime {
             PacketIo::Channel {
                 outgoing: outgoing_rx,
                 incoming: incoming_tx,
+                buffered_outgoing: None,
             },
             SupervisorContext {
                 profile: profile.clone(),
@@ -601,6 +637,7 @@ impl ManagedTunnelRuntime {
         Ok(Self {
             outgoing: Some(outgoing),
             incoming,
+            pending_incoming: PacketBatch::new(),
             cancellation,
             failure,
             health,
@@ -627,6 +664,22 @@ impl ManagedTunnelRuntime {
     }
 
     pub async fn receive_packet(&mut self) -> Result<Bytes, TransportError> {
+        loop {
+            if let Some(packet) = self.pending_incoming.pop_front() {
+                return Ok(packet);
+            }
+            self.pending_incoming = self
+                .incoming
+                .recv()
+                .await
+                .ok_or(TransportError::TunnelClosed)?;
+        }
+    }
+
+    pub(crate) async fn receive_batch(&mut self) -> Result<PacketBatch, TransportError> {
+        if !self.pending_incoming.is_empty() {
+            return Ok(std::mem::take(&mut self.pending_incoming));
+        }
         self.incoming
             .recv()
             .await
@@ -1079,21 +1132,59 @@ enum PacketIo {
     Pipe {
         rx: WakingPipeReceiver,
         tx: WakingPipeSender,
+        buffered_outgoing: Option<Bytes>,
     },
     Channel {
         outgoing: mpsc::Receiver<Bytes>,
-        incoming: mpsc::Sender<Bytes>,
+        incoming: mpsc::Sender<PacketBatch>,
+        buffered_outgoing: Option<Bytes>,
     },
+}
+
+enum TryOutgoingPacket {
+    Packet(Bytes),
+    Empty,
+    Closed,
+}
+
+type IncomingDeliveryFuture = Pin<Box<dyn Future<Output = bool> + Send + 'static>>;
+type TimedBatchSendResult =
+    Result<Result<PacketBatchResult, TransportError>, tokio::time::error::Elapsed>;
+type TimedBatchSendFuture = Pin<Box<dyn Future<Output = TimedBatchSendResult> + Send + 'static>>;
+
+fn start_timed_batch_send(future: BatchSendFuture) -> TimedBatchSendFuture {
+    Box::pin(timeout(PACKET_SEND_TIMEOUT, future))
+}
+
+async fn wait_for_batch_send(pending: &mut Option<TimedBatchSendFuture>) -> TimedBatchSendResult {
+    pending
+        .as_mut()
+        .expect("pending batch send is present while selected")
+        .await
+}
+
+async fn wait_for_incoming_delivery(pending: &mut Option<IncomingDeliveryFuture>) -> bool {
+    pending
+        .as_mut()
+        .expect("pending incoming delivery is present while selected")
+        .await
 }
 
 impl PacketIo {
     fn from_pipe(pipe: WakingPipe) -> Self {
         let WakingPipe { rx, tx } = pipe;
-        Self::Pipe { rx, tx }
+        Self::Pipe {
+            rx,
+            tx,
+            buffered_outgoing: None,
+        }
     }
 
     async fn receive_outgoing(&mut self) -> Option<Bytes> {
         loop {
+            if let Some(packet) = self.take_buffered_outgoing() {
+                return Some(packet);
+            }
             let packet = match self {
                 Self::Pipe { rx, .. } => rx.recv_async().await.map(|packet| {
                     let mut packet = packet
@@ -1127,13 +1218,91 @@ impl PacketIo {
         }
     }
 
-    async fn send_incoming(&mut self, packet: Bytes) -> bool {
+    async fn receive_outgoing_batch(&mut self) -> Option<PacketBatch> {
+        let first = self.receive_outgoing().await?;
+        let mut batch = PacketBatch::single(first);
+        while let TryOutgoingPacket::Packet(packet) = self.try_receive_outgoing() {
+            if let Err(packet) = batch.push_back(packet) {
+                self.store_buffered_outgoing(packet);
+                break;
+            }
+        }
+        Some(batch)
+    }
+
+    fn try_receive_outgoing(&mut self) -> TryOutgoingPacket {
+        loop {
+            if let Some(packet) = self.take_buffered_outgoing() {
+                return TryOutgoingPacket::Packet(packet);
+            }
+            let packet = match self {
+                Self::Pipe { rx, .. } => {
+                    if !rx.rx_ready() {
+                        return TryOutgoingPacket::Empty;
+                    }
+                    match rx.try_recv() {
+                        Some(packet) => packet,
+                        None => return TryOutgoingPacket::Closed,
+                    }
+                }
+                Self::Channel { outgoing, .. } => match outgoing.try_recv() {
+                    Ok(packet) => packet,
+                    Err(mpsc::error::TryRecvError::Empty) => return TryOutgoingPacket::Empty,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        return TryOutgoingPacket::Closed;
+                    }
+                },
+            };
+            let mut packet = packet
+                .try_into_mut()
+                .unwrap_or_else(|packet| bytes::BytesMut::from(packet.as_ref()));
+            if let Err(error) = prepare_forwarded_packet(&mut packet) {
+                tracing::warn!(%error, "discarded malformed packet while building a MASQUE batch");
+                continue;
+            }
+            return TryOutgoingPacket::Packet(packet.freeze());
+        }
+    }
+
+    fn take_buffered_outgoing(&mut self) -> Option<Bytes> {
+        match self {
+            Self::Pipe {
+                buffered_outgoing, ..
+            }
+            | Self::Channel {
+                buffered_outgoing, ..
+            } => buffered_outgoing.take(),
+        }
+    }
+
+    fn store_buffered_outgoing(&mut self, packet: Bytes) {
+        let slot = match self {
+            Self::Pipe {
+                buffered_outgoing, ..
+            }
+            | Self::Channel {
+                buffered_outgoing, ..
+            } => buffered_outgoing,
+        };
+        debug_assert!(slot.is_none());
+        *slot = Some(packet);
+    }
+
+    fn start_incoming_batch(&self, mut batch: PacketBatch) -> IncomingDeliveryFuture {
         match self {
             Self::Pipe { tx, .. } => {
-                tx.send_async(&packet).await;
-                true
+                let tx = tx.clone();
+                Box::pin(async move {
+                    while let Some(packet) = batch.pop_front() {
+                        tx.send_async(&packet).await;
+                    }
+                    true
+                })
             }
-            Self::Channel { incoming, .. } => incoming.send(packet).await.is_ok(),
+            Self::Channel { incoming, .. } => {
+                let incoming = incoming.clone();
+                Box::pin(async move { incoming.send(batch).await.is_ok() })
+            }
         }
     }
 }
@@ -1560,8 +1729,19 @@ async fn pump_active_tunnel(
         } else {
             None
         };
+    let mut pending_send: Option<TimedBatchSendFuture> = None;
+    let mut pending_incoming: Option<IncomingDeliveryFuture> = None;
+    let mut queued_incoming = VecDeque::new();
 
     let outcome = loop {
+        if cancellation.is_cancelled() {
+            break ActiveOutcome::Shutdown;
+        }
+        if pending_incoming.is_none()
+            && let Some(batch) = queued_incoming.pop_front()
+        {
+            pending_incoming = Some(packet_io.start_incoming_batch(batch));
+        }
         tokio::select! {
             _ = cancellation.cancelled() => break ActiveOutcome::Shutdown,
             _ = wait_for_network_change(&protector, network_generation), if network_generation.is_some() => {
@@ -1579,52 +1759,50 @@ async fn pump_active_tunnel(
                 );
                 break ActiveOutcome::Reconnect(failure);
             }
-            packet = packet_io.receive_outgoing() => {
-                let Some(packet) = packet else {
-                    break ActiveOutcome::Shutdown;
-                };
-                if !packet_allowed_by_peer_state(&packet, current_path) {
-                    tracing::warn!(
-                        family = packet.first().map(|byte| byte >> 4),
-                        "discarded a packet for an address family withdrawn by the CONNECT-IP peer"
-                    );
-                    continue;
-                }
-                let packet_length = packet.len();
-                // A cheap reference-counted view is retained only so an H3
-                // datagram-size rejection can be reflected as ICMP.
-                let retained_packet = packet.clone();
-                match timeout(PACKET_SEND_TIMEOUT, send.send_owned_packet(packet)).await {
-                    Ok(Ok(())) => {
-                        counters.sent.fetch_add(packet_length as u64, Ordering::Relaxed);
-                        telemetry.record_first_packet_sent(
-                            active_transport,
-                            active_path.endpoint_family,
-                        );
-                    }
-                    Ok(Err(TransportError::Http3DatagramTooLarge {
-                        maximum_packet_size,
-                    })) => {
-                        match crate::icmp::packet_too_big(&retained_packet, maximum_packet_size) {
-                            Ok(icmp) => {
-                                if !packet_io.send_incoming(icmp).await {
-                                    break ActiveOutcome::Shutdown;
+            result = wait_for_batch_send(&mut pending_send), if pending_send.is_some() => {
+                pending_send.take();
+                match result {
+                    Ok(Ok(PacketBatchResult { accepted_bytes, oversized })) => {
+                        if accepted_bytes != 0 {
+                            counters.sent.fetch_add(accepted_bytes as u64, Ordering::Relaxed);
+                            telemetry.record_first_packet_sent(
+                                active_transport,
+                                active_path.endpoint_family,
+                            );
+                        }
+                        let mut icmp_batch = PacketBatch::new();
+                        let mut oversized_outcome = None;
+                        for (packet, maximum_packet_size) in oversized {
+                            match crate::icmp::packet_too_big(&packet, maximum_packet_size) {
+                                Ok(icmp) => {
+                                    icmp_batch
+                                        .push_back(icmp)
+                                        .expect("one ICMP response per bounded packet batch fits");
+                                }
+                                Err(TransportError::Ipv6MinimumMtuUnavailable(maximum)) => {
+                                    let error =
+                                        TransportError::Ipv6MinimumMtuUnavailable(maximum);
+                                    oversized_outcome = Some(ActiveOutcome::Terminal(
+                                        error.failure(
+                                            Some(active_transport),
+                                            Some(active_path.endpoint_family),
+                                        ),
+                                    ));
+                                    break;
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        %error,
+                                        "failed to generate ICMP Packet Too Big"
+                                    );
                                 }
                             }
-                            Err(TransportError::Ipv6MinimumMtuUnavailable(maximum)) => {
-                                let error =
-                                    TransportError::Ipv6MinimumMtuUnavailable(maximum);
-                                break ActiveOutcome::Terminal(error.failure(
-                                    Some(active_transport),
-                                    Some(active_path.endpoint_family),
-                                ));
-                            }
-                            Err(error) => {
-                                tracing::warn!(
-                                    %error,
-                                    "failed to generate ICMP Packet Too Big"
-                                );
-                            }
+                        }
+                        if !icmp_batch.is_empty() {
+                            queued_incoming.push_back(icmp_batch);
+                        }
+                        if let Some(outcome) = oversized_outcome {
+                            break outcome;
                         }
                     }
                     Ok(Err(error)) => {
@@ -1645,24 +1823,59 @@ async fn pump_active_tunnel(
                     }
                 }
             }
-            result = receive.receive_packet() => {
+            delivered = wait_for_incoming_delivery(&mut pending_incoming), if pending_incoming.is_some() => {
+                pending_incoming.take();
+                if !delivered {
+                    break ActiveOutcome::Shutdown;
+                }
+            }
+            batch = packet_io.receive_outgoing_batch(), if pending_send.is_none() && queued_incoming.is_empty() => {
+                let Some(mut batch) = batch else {
+                    break ActiveOutcome::Shutdown;
+                };
+                let mut allowed = PacketBatch::new();
+                while let Some(packet) = batch.pop_front() {
+                    if !packet_allowed_by_peer_state(&packet, current_path) {
+                        tracing::warn!(
+                            family = packet.first().map(|byte| byte >> 4),
+                            "discarded a packet for an address family withdrawn by the CONNECT-IP peer"
+                        );
+                        continue;
+                    }
+                    allowed
+                        .push_back(packet)
+                        .expect("filtering cannot grow a bounded packet batch");
+                }
+                if allowed.is_empty() {
+                    continue;
+                }
+                pending_send = Some(start_timed_batch_send(send.start_owned_batch(allowed)));
+            }
+            result = receive.receive_batch(), if pending_incoming.is_none() => {
                 match result {
-                    Ok(packet) => {
-                        if !packet_allowed_by_peer_state(&packet, current_path) {
-                            tracing::warn!(
-                                family = packet.first().map(|byte| byte >> 4),
-                                "discarded a peer packet for an unavailable address family"
-                            );
+                    Ok(mut batch) => {
+                        let mut allowed = PacketBatch::new();
+                        while let Some(packet) = batch.pop_front() {
+                            if !packet_allowed_by_peer_state(&packet, current_path) {
+                                tracing::warn!(
+                                    family = packet.first().map(|byte| byte >> 4),
+                                    "discarded a peer packet for an unavailable address family"
+                                );
+                                continue;
+                            }
+                            allowed
+                                .push_back(packet)
+                                .expect("filtering cannot grow a bounded packet batch");
+                        }
+                        if allowed.is_empty() {
                             continue;
                         }
-                        counters.received.fetch_add(packet.len() as u64, Ordering::Relaxed);
+                        counters.received.fetch_add(allowed.bytes() as u64, Ordering::Relaxed);
                         telemetry.record_first_packet_received(
                             active_transport,
                             active_path.endpoint_family,
                         );
-                        if !packet_io.send_incoming(packet).await {
-                            break ActiveOutcome::Shutdown;
-                        }
+                        pending_incoming = Some(packet_io.start_incoming_batch(allowed));
                     }
                     Err(error) => {
                         tracing::debug!(%error, "active MASQUE packet receive failed");
@@ -1872,8 +2085,8 @@ async fn wait_while_dropping_packets(
             _ = wait_for_network_change(&protector, network_generation), if network_generation.is_some() => {
                 return true;
             }
-            packet = packet_io.receive_outgoing() => {
-                if packet.is_none() {
+            batch = packet_io.receive_outgoing_batch() => {
+                if batch.is_none() {
                     return false;
                 }
             }
@@ -1905,8 +2118,8 @@ async fn connect_while_dropping_packets(
                 return Some(Err(TransportError::UnderlyingNetworkChanged));
             }
             result = &mut connect => return Some(result),
-            packet = packet_io.receive_outgoing() => {
-                packet?;
+            batch = packet_io.receive_outgoing_batch() => {
+                batch?;
             }
         }
     }
@@ -2128,7 +2341,22 @@ fn ipv4_header_checksum(header: &[u8]) -> u16 {
 mod tests {
     use super::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
+    use tokio::sync::oneshot;
     use ts_netstack_smoltcp::CreateSocket;
+
+    fn test_ipv4_packet(sequence: u16) -> Bytes {
+        let mut packet = vec![0u8; 20];
+        packet[0] = 0x45;
+        packet[2..4].copy_from_slice(&20_u16.to_be_bytes());
+        packet[4..6].copy_from_slice(&sequence.to_be_bytes());
+        packet[8] = 64;
+        packet[9] = 17;
+        packet[12..16].copy_from_slice(&[192, 0, 2, 1]);
+        packet[16..20].copy_from_slice(&[198, 51, 100, 1]);
+        let checksum = ipv4_header_checksum(&packet);
+        packet[10..12].copy_from_slice(&checksum.to_be_bytes());
+        Bytes::from(packet)
+    }
 
     #[test]
     fn forwarding_decrements_ipv4_ttl_and_repairs_checksum() {
@@ -2147,6 +2375,147 @@ mod tests {
         packet[7] = 64;
         prepare_forwarded_packet(&mut packet).unwrap();
         assert_eq!(packet[7], 63);
+    }
+
+    #[tokio::test]
+    async fn managed_sender_backpressures_instead_of_dropping_or_closing() {
+        let telemetry = ConnectionTelemetry::default();
+        let (outgoing, mut receiver) = mpsc::channel(1);
+        let sender = ManagedTunnelSender {
+            outgoing,
+            telemetry: telemetry.clone(),
+        };
+        let first = test_ipv4_packet(1);
+        let second = test_ipv4_packet(2);
+        sender.send_owned_packet(first.clone()).await.unwrap();
+
+        let blocked_sender = sender.clone();
+        let blocked_packet = second.clone();
+        let blocked =
+            tokio::spawn(async move { blocked_sender.send_owned_packet(blocked_packet).await });
+        tokio::task::yield_now().await;
+        assert!(!blocked.is_finished());
+        assert_eq!(receiver.recv().await.unwrap(), first);
+        timeout(Duration::from_secs(1), blocked)
+            .await
+            .expect("sender did not resume after capacity returned")
+            .unwrap()
+            .unwrap();
+        assert_eq!(receiver.recv().await.unwrap(), second);
+
+        let metrics = telemetry.snapshot().metrics;
+        assert_eq!(metrics.send_queue_drop_count, 0);
+        assert_eq!(metrics.send_queue_high_watermark, 1);
+    }
+
+    #[tokio::test]
+    async fn closing_managed_receiver_releases_a_waiting_sender() {
+        let (outgoing, receiver) = mpsc::channel(1);
+        let sender = ManagedTunnelSender {
+            outgoing,
+            telemetry: ConnectionTelemetry::default(),
+        };
+        sender.send_owned_packet(test_ipv4_packet(1)).await.unwrap();
+        let waiting_sender = sender.clone();
+        let waiting =
+            tokio::spawn(
+                async move { waiting_sender.send_owned_packet(test_ipv4_packet(2)).await },
+            );
+        tokio::task::yield_now().await;
+        assert!(!waiting.is_finished());
+        drop(receiver);
+        let result = timeout(Duration::from_secs(1), waiting)
+            .await
+            .expect("sender did not wake when the receiver closed")
+            .unwrap();
+        assert!(matches!(result, Err(TransportError::TunnelClosed)));
+    }
+
+    #[tokio::test]
+    async fn packet_io_nonblocking_drain_batches_without_reordering() {
+        let (outgoing_tx, outgoing) = mpsc::channel(130);
+        let (incoming, _incoming_rx) = mpsc::channel(1);
+        for sequence in 0..130_u16 {
+            outgoing_tx.try_send(test_ipv4_packet(sequence)).unwrap();
+        }
+        drop(outgoing_tx);
+        let mut packet_io = PacketIo::Channel {
+            outgoing,
+            incoming,
+            buffered_outgoing: None,
+        };
+
+        let mut observed = Vec::new();
+        let mut batch_sizes = Vec::new();
+        while let Some(batch) = packet_io.receive_outgoing_batch().await {
+            batch_sizes.push(batch.len());
+            for packet in batch.iter() {
+                observed.push(u16::from_be_bytes([packet[4], packet[5]]));
+                assert_eq!(packet[8], 63);
+                assert_eq!(ipv4_header_checksum(packet), 0);
+            }
+        }
+        assert_eq!(batch_sizes, [64, 64, 2]);
+        assert_eq!(observed, (0..130_u16).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn pending_batch_send_does_not_mask_other_events_or_cancellation() {
+        let stalled: BatchSendFuture = Box::pin(std::future::pending());
+        let mut pending_send = Some(start_timed_batch_send(stalled));
+        let (event_tx, event_rx) = oneshot::channel();
+        event_tx.send("control").unwrap();
+        tokio::select! {
+            result = wait_for_batch_send(&mut pending_send) => {
+                panic!("stalled batch send completed unexpectedly: {result:?}");
+            }
+            event = event_rx => assert_eq!(event.unwrap(), "control"),
+        }
+        assert!(pending_send.is_some());
+
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {}
+            result = wait_for_batch_send(&mut pending_send) => {
+                panic!("stalled batch send masked cancellation: {result:?}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_incoming_delivery_does_not_mask_cancellation() {
+        let (_outgoing_tx, outgoing) = mpsc::channel(1);
+        let (incoming, mut incoming_rx) = mpsc::channel(1);
+        incoming
+            .send(PacketBatch::single(test_ipv4_packet(1)))
+            .await
+            .unwrap();
+        let packet_io = PacketIo::Channel {
+            outgoing,
+            incoming,
+            buffered_outgoing: None,
+        };
+        let mut pending_incoming =
+            Some(packet_io.start_incoming_batch(PacketBatch::single(test_ipv4_packet(2))));
+        tokio::task::yield_now().await;
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {}
+            delivered = wait_for_incoming_delivery(&mut pending_incoming) => {
+                panic!("blocked incoming delivery masked cancellation: {delivered}");
+            }
+        }
+
+        pending_incoming.take();
+        assert_eq!(
+            incoming_rx.recv().await.unwrap().pop_front().unwrap(),
+            test_ipv4_packet(1)
+        );
+        assert!(incoming_rx.try_recv().is_err());
     }
 
     #[test]

--- a/crates/usque-transport/src/packet_batch.rs
+++ b/crates/usque-transport/src/packet_batch.rs
@@ -1,0 +1,115 @@
+use std::collections::VecDeque;
+
+use bytes::Bytes;
+
+pub(crate) const MAX_PACKET_BATCH_PACKETS: usize = 64;
+pub(crate) const MAX_PACKET_BATCH_BYTES: usize = 256 * 1024;
+pub(crate) const PACKET_BATCH_CHANNEL_CAPACITY: usize = 1_024 / MAX_PACKET_BATCH_PACKETS;
+
+#[derive(Debug)]
+pub(crate) struct PacketBatch {
+    packets: VecDeque<Bytes>,
+    bytes: usize,
+}
+
+impl Default for PacketBatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PacketBatch {
+    pub(crate) fn new() -> Self {
+        Self {
+            packets: VecDeque::with_capacity(MAX_PACKET_BATCH_PACKETS),
+            bytes: 0,
+        }
+    }
+
+    pub(crate) fn single(packet: Bytes) -> Self {
+        let mut batch = Self::new();
+        batch
+            .push_back(packet)
+            .expect("one valid IP packet fits the batch byte bound");
+        batch
+    }
+
+    pub(crate) fn push_back(&mut self, packet: Bytes) -> Result<(), Bytes> {
+        if !self.can_accept(packet.len()) {
+            return Err(packet);
+        }
+        self.bytes += packet.len();
+        self.packets.push_back(packet);
+        Ok(())
+    }
+
+    pub(crate) fn pop_front(&mut self) -> Option<Bytes> {
+        let packet = self.packets.pop_front()?;
+        self.bytes = self.bytes.saturating_sub(packet.len());
+        Some(packet)
+    }
+
+    pub(crate) fn front(&self) -> Option<&Bytes> {
+        self.packets.front()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Bytes> {
+        self.packets.iter()
+    }
+
+    pub(crate) fn can_accept(&self, packet_bytes: usize) -> bool {
+        self.packets.len() < MAX_PACKET_BATCH_PACKETS
+            && self.bytes.saturating_add(packet_bytes) <= MAX_PACKET_BATCH_BYTES
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.packets.len()
+    }
+
+    pub(crate) fn bytes(&self) -> usize {
+        self.bytes
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.packets.is_empty()
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PacketBatchResult {
+    pub(crate) accepted_bytes: usize,
+    pub(crate) oversized: Vec<(Bytes, usize)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_preserves_order_and_packet_limit() {
+        let mut batch = PacketBatch::new();
+        for value in 0..MAX_PACKET_BATCH_PACKETS {
+            batch
+                .push_back(Bytes::from(vec![value as u8]))
+                .expect("packet fits");
+        }
+        assert_eq!(batch.len(), MAX_PACKET_BATCH_PACKETS);
+        assert!(batch.push_back(Bytes::from_static(b"overflow")).is_err());
+        for value in 0..MAX_PACKET_BATCH_PACKETS {
+            assert_eq!(batch.pop_front().unwrap().as_ref(), &[value as u8]);
+        }
+        assert!(batch.is_empty());
+        assert_eq!(batch.bytes(), 0);
+    }
+
+    #[test]
+    fn batch_enforces_byte_limit_without_consuming_overflow() {
+        let mut batch = PacketBatch::new();
+        let first = Bytes::from(vec![0; MAX_PACKET_BATCH_BYTES]);
+        batch.push_back(first).expect("exact limit fits");
+        let overflow = Bytes::from_static(b"overflow");
+        let returned = batch.push_back(overflow.clone()).unwrap_err();
+        assert_eq!(returned, overflow);
+        assert_eq!(batch.bytes(), MAX_PACKET_BATCH_BYTES);
+    }
+}

--- a/crates/usque-transport/src/telemetry.rs
+++ b/crates/usque-transport/src/telemetry.rs
@@ -97,6 +97,7 @@ pub struct ConnectionTelemetry {
     first_packet_received: Arc<AtomicBool>,
     send_queue_high_watermark: Arc<AtomicU64>,
     send_queue_drop_count: Arc<AtomicU64>,
+    send_queue_wait_count: Arc<AtomicU64>,
 }
 
 /// Carries the path identity for one in-flight transport attempt so lower
@@ -166,6 +167,7 @@ impl ConnectionTelemetry {
             first_packet_received: Arc::new(AtomicBool::new(false)),
             send_queue_high_watermark: Arc::new(AtomicU64::new(0)),
             send_queue_drop_count: Arc::new(AtomicU64::new(0)),
+            send_queue_wait_count: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -297,6 +299,28 @@ impl ConnectionTelemetry {
         );
     }
 
+    pub fn record_queue_saturated(&self, queue_depth: usize) {
+        let wait_count = self
+            .send_queue_wait_count
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
+        if !wait_count.is_power_of_two() {
+            return;
+        }
+        let failure = TransportFailure::new(
+            TransportFailureCode::SendQueueFull,
+            TransportStage::PacketSend,
+        )
+        .with_sanitized_detail(format!("queue depth {queue_depth}"));
+        self.record(
+            ConnectionEventType::QueueSaturated,
+            Some(TransportStage::PacketSend),
+            ConnectionEventPath::default(),
+            None,
+            Some(failure),
+        );
+    }
+
     pub fn set_reconnect(&self, count: u32, failure: &TransportFailure) {
         let mut state = self.state();
         state.metrics.reconnect_count = count;
@@ -373,6 +397,9 @@ mod tests {
         telemetry.observe_queue_depth(3);
         telemetry.record_queue_drop();
         telemetry.record_queue_drop();
+        telemetry.record_queue_saturated(1_024);
+        telemetry.record_queue_saturated(1_024);
+        telemetry.record_queue_saturated(1_024);
 
         let snapshot = telemetry.snapshot();
         assert_eq!(snapshot.metrics.send_queue_high_watermark, 7);
@@ -383,7 +410,18 @@ mod tests {
                 .iter()
                 .filter(|event| event.event_type == ConnectionEventType::QueueSaturated)
                 .count(),
-            2
+            4
+        );
+        let saturation_details = snapshot
+            .events
+            .iter()
+            .filter(|event| event.event_type == ConnectionEventType::QueueSaturated)
+            .filter_map(|event| event.failure.as_ref())
+            .filter_map(|failure| failure.sanitized_detail.as_deref())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            saturation_details,
+            vec!["queue depth 1024", "queue depth 1024"]
         );
     }
 

--- a/crates/usque-transport/src/tunnel.rs
+++ b/crates/usque-transport/src/tunnel.rs
@@ -1,10 +1,16 @@
-use bytes::Bytes;
+use std::future::Future;
+use std::pin::Pin;
+
 use tokio::sync::watch;
 use usque_core::Transport;
 use usque_protocol::PeerNetworkState;
 
 use crate::h2::{H2Driver, H2ReceiveHalf, H2SendHalf, H2Tunnel, TransportError};
 use crate::h3::{H3Driver, H3ReceiveHalf, H3SendHalf, H3Tunnel};
+use crate::packet_batch::{PacketBatch, PacketBatchResult};
+
+pub(crate) type BatchSendFuture =
+    Pin<Box<dyn Future<Output = Result<PacketBatchResult, TransportError>> + Send + 'static>>;
 
 /// One active MASQUE data channel. The enum deliberately has no fan-out or
 /// multipath variant: Auto may replace a channel, but only one channel carries
@@ -59,10 +65,10 @@ pub(crate) enum MasqueSendHalf {
 }
 
 impl MasqueSendHalf {
-    pub(crate) async fn send_owned_packet(&mut self, packet: Bytes) -> Result<(), TransportError> {
+    pub(crate) fn start_owned_batch(&self, batch: PacketBatch) -> BatchSendFuture {
         match self {
-            Self::Http3(send) => send.send_owned_packet(packet).await,
-            Self::Http2(send) => send.send_owned_packet(packet).await,
+            Self::Http3(send) => send.start_owned_batch(batch),
+            Self::Http2(send) => send.start_owned_batch(batch),
         }
     }
 
@@ -80,10 +86,10 @@ pub(crate) enum MasqueReceiveHalf {
 }
 
 impl MasqueReceiveHalf {
-    pub(crate) async fn receive_packet(&mut self) -> Result<Bytes, TransportError> {
+    pub(crate) async fn receive_batch(&mut self) -> Result<PacketBatch, TransportError> {
         match self {
-            Self::Http3(receive) => receive.receive_packet().await,
-            Self::Http2(receive) => receive.receive_packet().await,
+            Self::Http3(receive) => receive.receive_batch().await,
+            Self::Http2(receive) => receive.receive_batch().await,
         }
     }
 }

--- a/docs/GITHUB_GOVERNANCE.md
+++ b/docs/GITHUB_GOVERNANCE.md
@@ -42,4 +42,4 @@ Details are in [RELEASE.md](RELEASE.md):
 
 - A fork pull request gets a read-only token, cannot read secrets, and cannot upload an installable package.
 - Dependency Review runs on public pull requests.
-- The README treats only files from the `v0.2.2` GitHub Release as official.
+- The README treats only files from the `v0.2.3` GitHub Release as official.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,15 +1,15 @@
 # Installation and removal
 
-Install only packages from this repository's [GitHub Releases page](https://github.com/GeorgeXie2333/usque-app/releases) for `v0.2.2`.
+Install only packages from this repository's [GitHub Releases page](https://github.com/GeorgeXie2333/usque-app/releases) for `v0.2.3`.
 
 ## Official packages
 
-- `usque-v0.2.2-windows-x64-v2.msi`
-- `usque-v0.2.2-windows-arm64.msi`
-- `usque-v0.2.2-android-arm64-v8a.apk`
-- `usque-v0.2.2-android-x86_64.apk`
-- `usque-v0.2.2-android-armeabi-v7a.apk`
-- `usque-v0.2.2-android-universal.apk`
+- `usque-v0.2.3-windows-x64-v2.msi`
+- `usque-v0.2.3-windows-arm64.msi`
+- `usque-v0.2.3-android-arm64-v8a.apk`
+- `usque-v0.2.3-android-x86_64.apk`
+- `usque-v0.2.3-android-armeabi-v7a.apk`
+- `usque-v0.2.3-android-universal.apk`
 
 The GitHub Release attaches those six packages plus `release-manifest.json`,
 `SHA256SUMS`, and each package's SPDX SBOM. GitHub shows a SHA-256 for each

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,12 +1,12 @@
-# How v0.2.2 is published
+# How v0.2.3 is published
 
-`v0.2.2` is built by the tag workflow on the current `main` commit. The `v0.2.2` tag is maintainer-only. Signing and publish jobs run in GitHub Environments that need approval. If a required file, signature input, or CI result is missing, the workflow fails. A local MSI or APK cannot replace a failed Actions build.
+`v0.2.3` is built by the tag workflow on the current `main` commit. The `v0.2.3` tag is maintainer-only. Signing and publish jobs run in GitHub Environments that need approval. If a required file, signature input, or CI result is missing, the workflow fails. A local MSI or APK cannot replace a failed Actions build.
 
 Which signatures count as official, how fingerprints are published, and what happens if a key is lost or leaked are in [CODE_SIGNING.md](CODE_SIGNING.md). Repository rules around this workflow are in [GITHUB_GOVERNANCE.md](GITHUB_GOVERNANCE.md).
 
 ## Before signing starts
 
-- The tag must be `v0.2.2` and must point at the current `main` commit.
+- The tag must be `v0.2.3` and must point at the current `main` commit.
 - That commit must already have a successful `ci.yml` push run, including `CI / gate`.
 - `release-signing` and `release-publish` both require approval.
 - Android Developer Console must show `io.github.georgexie2333.usque` and the certificate fingerprint in `ANDROID_SIGNER_SHA256` as **Registered**.
@@ -69,12 +69,12 @@ unrendered or partially rendered body.
 
 Primary files:
 
-- `usque-v0.2.2-windows-x64-v2.msi`
-- `usque-v0.2.2-windows-arm64.msi`
-- `usque-v0.2.2-android-arm64-v8a.apk`
-- `usque-v0.2.2-android-x86_64.apk`
-- `usque-v0.2.2-android-armeabi-v7a.apk`
-- `usque-v0.2.2-android-universal.apk`
+- `usque-v0.2.3-windows-x64-v2.msi`
+- `usque-v0.2.3-windows-arm64.msi`
+- `usque-v0.2.3-android-arm64-v8a.apk`
+- `usque-v0.2.3-android-x86_64.apk`
+- `usque-v0.2.3-android-armeabi-v7a.apk`
+- `usque-v0.2.3-android-universal.apk`
 
 In addition to the six install packages, the public release includes
 `release-manifest.json`, `SHA256SUMS`, and each package's SPDX SBOM. A public
@@ -92,7 +92,7 @@ MSI build = SemVer patch * 100 + beta ordinal
 stable ordinal = 99
 ```
 
-Stable `v0.2.2` is therefore MSI ProductVersion `0.2.299`. The real SemVer stays in ProductName and the filenames. Equal-version major upgrades are enabled so a validation build can replace the same product instead of installing a second copy under `Program Files\Usque`. WiX validation suppresses only ICE61, which assumes upgrades must raise the version; every other standard ICE check stays on.
+Stable `v0.2.3` is therefore MSI ProductVersion `0.2.399`. The real SemVer stays in ProductName and the filenames. Equal-version major upgrades are enabled so a validation build can replace the same product instead of installing a second copy under `Program Files\Usque`. WiX validation suppresses only ICE61, which assumes upgrades must raise the version; every other standard ICE check stays on.
 
 The Agent is installed as demand-start and is not started by the MSI. Its
 `MsiLockPermissionsEx` descriptor gives `SYSTEM` and Administrators full service

--- a/tool/build_windows_local_validation.ps1
+++ b/tool/build_windows_local_validation.ps1
@@ -2,7 +2,7 @@
 param(
     [ValidateSet("x64-v1", "x64-v2", "arm64")]
     [string]$Variant = "x64-v2",
-    [string]$Version = "0.2.2",
+    [string]$Version = "0.2.3",
     [string]$BuildLabel = "local-validation",
     [string]$FlutterReleaseDirectory = "",
     [string]$OutputDirectory = ""

--- a/tool/test_release_contract.py
+++ b/tool/test_release_contract.py
@@ -12,7 +12,7 @@ class ReleaseContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary.name)
-        self.tag = "v0.2.2"
+        self.tag = "v0.2.3"
         self.commit = "a" * 40
         for name in release_contract.expected_artifact_names(self.tag):
             (self.root / name).write_bytes(name.encode())
@@ -157,15 +157,15 @@ class ReleaseVersionContractTests(unittest.TestCase):
         (self.root / ".github" / "workflows").mkdir(parents=True)
         (self.root / "apps" / "usque_gui" / "lib" / "core" / "l10n").mkdir(parents=True)
         (self.root / "Cargo.toml").write_text(
-            '[workspace]\n[workspace.package]\nversion = "0.2.2"\n',
+            '[workspace]\n[workspace.package]\nversion = "0.2.3"\n',
             encoding="utf-8",
         )
         (self.root / "apps" / "usque_gui" / "pubspec.yaml").write_text(
-            "name: usque\nversion: 0.2.2+16\n", encoding="utf-8"
+            "name: usque\nversion: 0.2.3+17\n", encoding="utf-8"
         )
         for name in ("en.dart", "zh_cn.dart"):
             (self.root / "apps" / "usque_gui" / "lib" / "core" / "l10n" / name).write_text(
-                "const catalog = <String, String>{\n  'app_version': 'Usque 0.2.2',\n};\n",
+                "const catalog = <String, String>{\n  'app_version': 'Usque 0.2.3',\n};\n",
                 encoding="utf-8",
             )
         self.workflow_path = self.root / ".github" / "workflows" / "release.yml"
@@ -173,10 +173,10 @@ class ReleaseVersionContractTests(unittest.TestCase):
             "on:\n"
             "  push:\n"
             "    tags:\n"
-            '      - "v0.2.2"\n'
+            '      - "v0.2.3"\n'
             "env:\n"
-            "  RELEASE_TAG: v0.2.2\n"
-            '  ANDROID_VERSION_CODE: "16"\n',
+            "  RELEASE_TAG: v0.2.3\n"
+            '  ANDROID_VERSION_CODE: "17"\n',
             encoding="utf-8",
         )
 
@@ -184,25 +184,25 @@ class ReleaseVersionContractTests(unittest.TestCase):
         self.temporary.cleanup()
 
     def test_accepts_consistent_release_version_surfaces(self) -> None:
-        release_contract.verify_release_version(self.root, "v0.2.2", 16)
+        release_contract.verify_release_version(self.root, "v0.2.3", 17)
 
     def test_rejects_cargo_or_flutter_version_drift(self) -> None:
+        (self.root / "Cargo.toml").write_text(
+            '[workspace]\n[workspace.package]\nversion = "0.2.4"\n',
+            encoding="utf-8",
+        )
+        with self.assertRaises(release_contract.ContractError):
+            release_contract.verify_release_version(self.root, "v0.2.3", 17)
+
         (self.root / "Cargo.toml").write_text(
             '[workspace]\n[workspace.package]\nversion = "0.2.3"\n',
             encoding="utf-8",
         )
-        with self.assertRaises(release_contract.ContractError):
-            release_contract.verify_release_version(self.root, "v0.2.2", 16)
-
-        (self.root / "Cargo.toml").write_text(
-            '[workspace]\n[workspace.package]\nversion = "0.2.2"\n',
-            encoding="utf-8",
-        )
         (self.root / "apps" / "usque_gui" / "pubspec.yaml").write_text(
-            "name: usque\nversion: 0.2.3+16\n", encoding="utf-8"
+            "name: usque\nversion: 0.2.4+17\n", encoding="utf-8"
         )
         with self.assertRaises(release_contract.ContractError):
-            release_contract.verify_release_version(self.root, "v0.2.2", 16)
+            release_contract.verify_release_version(self.root, "v0.2.3", 17)
 
     def test_rejects_locale_or_workflow_version_drift(self) -> None:
         locale = self.root / "apps" / "usque_gui" / "lib" / "core" / "l10n" / "en.dart"
@@ -211,20 +211,20 @@ class ReleaseVersionContractTests(unittest.TestCase):
             encoding="utf-8",
         )
         with self.assertRaises(release_contract.ContractError):
-            release_contract.verify_release_version(self.root, "v0.2.2", 16)
+            release_contract.verify_release_version(self.root, "v0.2.3", 17)
 
         locale.write_text(
-            "const catalog = <String, String>{\n  'app_version': 'Usque 0.2.2',\n};\n",
+            "const catalog = <String, String>{\n  'app_version': 'Usque 0.2.3',\n};\n",
             encoding="utf-8",
         )
         self.workflow_path.write_text(
             self.workflow_path.read_text(encoding="utf-8").replace(
-                "RELEASE_TAG: v0.2.2", "RELEASE_TAG: v0.2.3"
+                "RELEASE_TAG: v0.2.3", "RELEASE_TAG: v0.2.4"
             ),
             encoding="utf-8",
         )
         with self.assertRaises(release_contract.ContractError):
-            release_contract.verify_release_version(self.root, "v0.2.2", 16)
+            release_contract.verify_release_version(self.root, "v0.2.3", 17)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Ship v0.2.3 as a major MASQUE stability bug-fix release.
- Backpressure bounded H3/H2 and platform packet queues without premature send failure or packet loss.
- Preserve ordered recovery on Windows and Android, and refresh release/version contracts and bilingual notes.
- Keep protected self-hosted reliability validation explicitly opt-in and non-blocking.

## Validation

- release_contract.py verify-version --root . --tag v0.2.3 --android-version-code 17
- Python unittest discovery: 39 passed
- cargo metadata --locked and cargo fmt --all --check
- Windows Rust helper: clippy, all workspace tests, and x64-v2 release build
- Flutter 3.44.7 pinned revision: locked pub resolve, format, analyze, 176 tests, Windows release build
- Android Rust arm64 Clippy; Gradle ktlint, testDebugUnitTest, and lintDebug
- Ruff check and format check; both PSScriptAnalyzer passes
- Buf lint, format, and breaking check against origin/main
- actionlint 1.7.12
- Frozen Go oracle module verification, archive verification, and tests
- x64 and ARM64 inert MSI authoring, table contracts, version mapping, and ICE validation
- Repository policy and git diff --check

The aggregate tool/check_source.ps1 reached the documented plain-shell VS 18/CMake BoringSSL trap during Rust Clippy. Per AGENTS.md, only boring-sys was cleaned and the required Windows helper completed Clippy, tests, and release compilation successfully.

## Not run

- Optional protected Windows VM, Android device, external network observer, and performance lab validation.
- MSI or APK installation, VPN/TUN startup, WFP, route, DNS, or system-proxy mutation.

## Release safety

- No public API, protobuf field, or configuration schema change.
- No signing material, generated JNI library, local.properties, build output, or release artifact is committed.