### PR TITLE
fix(windows): restore signed Burn engine before verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -700,6 +700,12 @@ jobs:
           & ./tool/test_windows_msi_localization.ps1 `
             -MsiPath (Join-Path $msiDirectory "usque-v0.2.6-windows-${{ matrix.variant }}-ja-JP.msi")
 
+      - name: Verify signed Burn engine round trip without installation
+        shell: pwsh
+        run: |
+          & ./tool/test_windows_burn_engine.ps1 `
+            -BundlePath (Join-Path $env:RUNNER_TEMP "windows-authoring-${{ matrix.arch }}/usque-v0.2.6-windows-${{ matrix.variant }}.exe")
+
   gate:
     name: CI / gate
     if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,15 @@ checks a valid package and then proves ICE03 rejects the malformed localized
 format string on a temporary copy. Do not suppress validation diagnostics or
 substitute validation of only the final culture for the complete language set.
 
+Run `tool/test_windows_burn_engine.ps1 -BundlePath <inert fixture bundle>` for
+both architectures. It signs only temporary engine/bundle copies with a fresh
+non-exportable test identity in `CurrentUser\My`, never a trust store, and
+removes that identity and its key afterward. It checks byte-identical signed
+engine recovery, tamper/wrong-pin rejection, malformed headers, and read-only
+inputs. The test never executes a bundle or installs an MSI. Raw `wix burn
+detach` is for the pre-signing step: verifying an engine from an already signed
+bundle requires restoring the PE signature/checksum fields as Burn itself does.
+
 For quiet-uninstall changes, run `pwsh -NoProfile -File
 tool/test_windows_quiet_uninstall.ps1` and the same test script with Windows
 PowerShell 5.1. These use inert process/registry doubles and a harmless child

--- a/docs/CODE_SIGNING.md
+++ b/docs/CODE_SIGNING.md
@@ -44,6 +44,10 @@ release signs the MSI before embedding it, then follows WiX's detach/sign/
 reattach/sign sequence so both the Burn engine and final bundle carry the same
 project identity. A signer mismatch, a modified Wintun DLL, a malformed
 language transform, or a missing official fingerprint fails the release.
+For verification of an already signed bundle, the engine extractor restores
+the original PE checksum and certificate directory, matching Burn's cached
+engine behavior, before checking Authenticode and the fixed signer. Raw
+`wix burn detach` alone is not a signed-engine verification extractor.
 The installed uninstall helper applies the same offline Authenticode policy
 before it runs a cached hidden bundle for registration cleanup.
 

--- a/tool/extract_windows_burn_engine.ps1
+++ b/tool/extract_windows_burn_engine.ps1
@@ -1,0 +1,150 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$BundlePath,
+    [Parameter(Mandatory = $true)][string]$OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# WiX 5.0.2 burn detach copies the engine prefix without restoring its PE
+# signature directory. Reproduce Burn's cache.cpp signed-engine header
+# restoration instead; the caller must still verify Authenticode and the pin.
+# Format: WiX v5.0.2 Bundles/BurnCommon.cs and src/burn/engine/cache.cpp.
+function Read-BurnUInt32 {
+    param([IO.BinaryReader]$Reader, [long]$Offset)
+    if ($Offset -lt 0 -or $Offset -gt $Reader.BaseStream.Length - 4) {
+        throw "Truncated Burn/PE field."
+    }
+    $Reader.BaseStream.Position = $Offset
+    return $Reader.ReadUInt32()
+}
+
+$sourcePath = (Resolve-Path -LiteralPath $BundlePath -ErrorAction Stop).Path
+$destinationPath = [IO.Path]::GetFullPath($OutputPath)
+if (Test-Path -LiteralPath $destinationPath) {
+    throw "Burn engine output must not already exist."
+}
+$source = [IO.File]::Open($sourcePath, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::Read)
+$reader = [IO.BinaryReader]::new($source)
+$destination = $null
+$writer = $null
+$createdOutput = $false
+$completed = $false
+try {
+    if ($source.Length -lt 64 -or $reader.ReadUInt16() -ne 0x5A4D) {
+        throw "Burn bundle is not a DOS/PE executable."
+    }
+    [long]$peOffset = Read-BurnUInt32 $reader 0x3C
+    if ($peOffset -lt 64 -or (Read-BurnUInt32 $reader $peOffset) -ne 0x00004550) {
+        throw "Invalid Burn PE header."
+    }
+    $machineAndCount = Read-BurnUInt32 $reader ($peOffset + 4)
+    $machine = $machineAndCount -band 0xFFFF
+    [long]$sectionCount = $machineAndCount -shr 16
+    if ($machine -notin @(0x8664, 0xAA64) -or $sectionCount -lt 1 -or $sectionCount -gt 96) {
+        throw "Unsupported Burn PE architecture or section count."
+    }
+    [long]$optionalSize = (Read-BurnUInt32 $reader ($peOffset + 20)) -band 0xFFFF
+    [long]$optionalOffset = $peOffset + 24
+    if (
+        $optionalSize -lt 152 -or
+        ((Read-BurnUInt32 $reader $optionalOffset) -band 0xFFFF) -ne 0x20B -or
+        (Read-BurnUInt32 $reader ($optionalOffset + 108)) -lt 5
+    ) {
+        throw "Burn requires a PE32+ certificate directory."
+    }
+    [long]$sectionTable = $optionalOffset + $optionalSize
+    [long]$sectionTableEnd = $sectionTable + 40 * $sectionCount
+    if ($sectionTableEnd -gt $source.Length) { throw "Truncated Burn section table." }
+
+    $burnSections = @()
+    for ($index = 0; $index -lt $sectionCount; $index++) {
+        $entry = $sectionTable + 40 * $index
+        $source.Position = $entry
+        $name = [Text.Encoding]::ASCII.GetString($reader.ReadBytes(8))
+        if ($name -ceq '.wixburn') {
+            $burnSections += @{
+                Offset = [long](Read-BurnUInt32 $reader ($entry + 20))
+                Size = [long](Read-BurnUInt32 $reader ($entry + 16))
+            }
+        }
+    }
+    if ($burnSections.Count -ne 1) { throw "Expected exactly one .wixburn section." }
+    [long]$burnOffset = $burnSections[0].Offset
+    [long]$burnSize = $burnSections[0].Size
+    if ($burnOffset -lt $sectionTableEnd -or $burnSize -lt 56 -or $burnOffset + $burnSize -gt $source.Length) {
+        throw "Invalid .wixburn section bounds."
+    }
+    if (
+        (Read-BurnUInt32 $reader $burnOffset) -ne 0x00F14300 -or
+        (Read-BurnUInt32 $reader ($burnOffset + 4)) -ne 2 -or
+        (Read-BurnUInt32 $reader ($burnOffset + 40)) -ne 1
+    ) {
+        throw "Unsupported .wixburn magic, version, or container format."
+    }
+    [long]$stubSize = Read-BurnUInt32 $reader ($burnOffset + 24)
+    $originalChecksum = Read-BurnUInt32 $reader ($burnOffset + 28)
+    [long]$signatureOffset = Read-BurnUInt32 $reader ($burnOffset + 32)
+    [long]$signatureSize = Read-BurnUInt32 $reader ($burnOffset + 36)
+    [long]$containerCount = Read-BurnUInt32 $reader ($burnOffset + 44)
+    [long]$uxSize = Read-BurnUInt32 $reader ($burnOffset + 48)
+    if ($containerCount -lt 2 -or 48 + 4 * $containerCount -gt $burnSize) {
+        throw "Invalid Burn attached-container count."
+    }
+    [long]$engineSize = $signatureOffset + $signatureSize
+    if (
+        $stubSize -lt $burnOffset + $burnSize -or $uxSize -eq 0 -or
+        $signatureOffset -lt $stubSize + $uxSize -or $signatureSize -lt 8 -or
+        $signatureOffset % 8 -ne 0 -or $signatureSize % 8 -ne 0 -or
+        $engineSize -gt $source.Length
+    ) {
+        throw "Missing or invalid embedded Burn engine signature bounds."
+    }
+    [long]$certificateLength = Read-BurnUInt32 $reader $signatureOffset
+    if (
+        $certificateLength -lt 8 -or $certificateLength -gt $signatureSize -or
+        (Read-BurnUInt32 $reader ($signatureOffset + 4)) -ne 0x00020200
+    ) {
+        throw "Invalid embedded Burn WIN_CERTIFICATE header."
+    }
+    [long]$payloadEnd = $engineSize
+    for ($index = 1; $index -lt $containerCount; $index++) {
+        $payloadEnd += Read-BurnUInt32 $reader ($burnOffset + 48 + 4 * $index)
+    }
+    if ($payloadEnd -gt $source.Length) { throw "Truncated Burn attached payload." }
+
+    # Never overwrite the bundle or an existing file. Open the source read-only
+    # throughout parsing/copying so another writer cannot race the validated data.
+    $destination = [IO.File]::Open($destinationPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+    $createdOutput = $true
+    $source.Position = 0
+    $buffer = [byte[]]::new(65536)
+    [long]$remaining = $engineSize
+    while ($remaining -gt 0) {
+        $count = $source.Read($buffer, 0, [int][Math]::Min($buffer.Length, $remaining))
+        if ($count -eq 0) { throw "Truncated Burn engine while copying." }
+        $destination.Write($buffer, 0, $count)
+        $remaining -= $count
+    }
+    $writer = [IO.BinaryWriter]::new($destination)
+    $destination.Position = $optionalOffset + 64
+    $writer.Write([uint32]$originalChecksum)
+    $destination.Position = $optionalOffset + 144
+    $writer.Write([uint32]$signatureOffset)
+    $writer.Write([uint32]$signatureSize)
+    $destination.Position = $burnOffset + 28
+    $writer.Write([byte[]]::new(12))
+    $writer.Flush()
+    $completed = $true
+}
+finally {
+    if ($null -ne $writer) { $writer.Dispose() }
+    if ($null -ne $destination) { $destination.Dispose() }
+    $reader.Dispose()
+    $source.Dispose()
+    if ($createdOutput -and -not $completed) {
+        Remove-Item -LiteralPath $destinationPath -Force
+    }
+}
+Write-Output $destinationPath

--- a/tool/test_release_contract.py
+++ b/tool/test_release_contract.py
@@ -199,6 +199,18 @@ class WindowsInstallerValidationPolicyTests(unittest.TestCase):
         calls = re.findall(r"(?m)^\s*& \$buildMsi\b[^|]+\| ([^\n]+)", builder)
         self.assertEqual(["Out-Host", "Out-Host"], calls)
 
+    def test_bundle_signature_gate_restores_engine_without_skipping_authenticode(self) -> None:
+        root = Path(__file__).resolve().parent.parent
+        verifier = (root / "tool/verify_windows_bundle.ps1").read_text(encoding="utf-8")
+        self.assertIn('"extract_windows_burn_engine.ps1"', verifier)
+        self.assertNotIn("wix -- burn detach", verifier)
+        restored_check = verifier.split('"extract_windows_burn_engine.ps1"', 1)[1]
+        self.assertIn('"verify_windows_authenticode.ps1"', restored_check)
+        self.assertIn("-Path $detachedEngine", restored_check)
+        self.assertIn("-SignerSha256 $SignerSha256", restored_check)
+        workflow = (root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.assertIn("tool/test_windows_burn_engine.ps1", workflow)
+
 
 class ReleaseVersionContractTests(unittest.TestCase):
     def setUp(self) -> None:

--- a/tool/test_windows_burn_engine.ps1
+++ b/tool/test_windows_burn_engine.ps1
@@ -1,0 +1,169 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$BundlePath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-Rejected {
+    param([scriptblock]$Action, [string]$MessagePattern)
+    $rejected = $false
+    try { & $Action | Out-Null }
+    catch {
+        if ($_.Exception.Message -notlike $MessagePattern) { throw }
+        $rejected = $true
+    }
+    if (-not $rejected) { throw "Expected rejection: $MessagePattern" }
+}
+
+function Set-TestSignature {
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$File, [Security.Cryptography.X509Certificates.X509Certificate2]$Certificate)
+    if ($PSCmdlet.ShouldProcess($File, "Apply and verify temporary test signature")) {
+        Set-AuthenticodeSignature -FilePath $File -Certificate $Certificate -HashAlgorithm SHA256 | Out-Null
+        & (Join-Path $PSScriptRoot "verify_windows_authenticode.ps1") `
+            -Path $File `
+            -SignerSha256 $Certificate.GetCertHashString([Security.Cryptography.HashAlgorithmName]::SHA256) `
+            -AllowPinnedUntrustedRoot | Out-Null
+    }
+}
+
+$sourceBundle = (Resolve-Path -LiteralPath $BundlePath).Path
+$sourceHash = (Get-FileHash -LiteralPath $sourceBundle -Algorithm SHA256).Hash
+$temporaryRoot = Join-Path ([IO.Path]::GetTempPath()) "usque-burn-test-$([guid]::NewGuid().ToString('N'))"
+$safeTempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath()).TrimEnd('\') + '\'
+$temporaryRoot = [IO.Path]::GetFullPath($temporaryRoot)
+if (-not $temporaryRoot.StartsWith($safeTempRoot, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Invalid Burn test temporary directory."
+}
+New-Item -ItemType Directory -Path $temporaryRoot | Out-Null
+$certificate = $null
+$extract = Join-Path $PSScriptRoot "extract_windows_burn_engine.ps1"
+$verify = Join-Path $PSScriptRoot "verify_windows_authenticode.ps1"
+try {
+    # A fresh, untrusted test identity only. Never export its key, import it
+    # into a trust store, sign Wintun, execute the bundle, or install its MSI.
+    $certificate = New-SelfSignedCertificate `
+        -Type CodeSigningCert `
+        -Subject "CN=Usque inert Burn test $([guid]::NewGuid().ToString('N'))" `
+        -CertStoreLocation "Cert:\CurrentUser\My" `
+        -KeyAlgorithm RSA `
+        -KeyLength 2048 `
+        -HashAlgorithm SHA256 `
+        -KeyExportPolicy NonExportable `
+        -NotAfter ([DateTime]::Now.AddDays(1))
+    $signer = $certificate.GetCertHashString([Security.Cryptography.HashAlgorithmName]::SHA256)
+    $engine = Join-Path $temporaryRoot "engine.exe"
+    $signedBundle = Join-Path $temporaryRoot "signed-bundle.exe"
+    $rawDetached = Join-Path $temporaryRoot "raw-detached.exe"
+    $restored = Join-Path $temporaryRoot "restored.exe"
+    & dotnet tool run wix -- burn detach $sourceBundle -engine $engine -intermediateFolder $temporaryRoot
+    if ($LASTEXITCODE -ne 0) { throw "Test engine detach failed." }
+    Set-TestSignature $engine $certificate
+    $engineHash = (Get-FileHash -LiteralPath $engine -Algorithm SHA256).Hash
+    & dotnet tool run wix -- burn reattach $sourceBundle -engine $engine -out $signedBundle -intermediateFolder $temporaryRoot
+    if ($LASTEXITCODE -ne 0) { throw "Test engine reattach failed." }
+    Set-TestSignature $signedBundle $certificate
+    $bundleHash = (Get-FileHash -LiteralPath $signedBundle -Algorithm SHA256).Hash
+
+    # Reproduce the former release failure before testing the repaired path.
+    & dotnet tool run wix -- burn detach $signedBundle -engine $rawDetached -intermediateFolder $temporaryRoot
+    if ($LASTEXITCODE -ne 0) { throw "Signed test bundle detach failed." }
+    Assert-Rejected {
+        & $verify -Path $rawDetached -SignerSha256 $signer -AllowPinnedUntrustedRoot
+    } "No signer certificate was returned*"
+    & $extract -BundlePath $signedBundle -OutputPath $restored | Out-Null
+    & $verify -Path $restored -SignerSha256 $signer -AllowPinnedUntrustedRoot | Out-Null
+    if ((Get-FileHash -LiteralPath $restored -Algorithm SHA256).Hash -cne $engineHash) {
+        throw "Restored engine differs from the originally signed engine."
+    }
+    Write-Output "BURN_SIGNED_ROUND_TRIP_OK"
+
+    Assert-Rejected {
+        & $verify -Path $restored -SignerSha256 ("0" * 64) -AllowPinnedUntrustedRoot
+    } "Unexpected signer*"
+    $tampered = Join-Path $temporaryRoot "tampered-engine.exe"
+    Copy-Item -LiteralPath $restored -Destination $tampered
+    $file = [IO.File]::Open($tampered, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite)
+    try {
+        $file.Position = 0x40
+        $value = $file.ReadByte()
+        $file.Position = 0x40
+        $file.WriteByte([byte]($value -bxor 1))
+    }
+    finally { $file.Dispose() }
+    Assert-Rejected {
+        & $verify -Path $tampered -SignerSha256 $signer -AllowPinnedUntrustedRoot
+    } "Authenticode verification failed*"
+    Assert-Rejected {
+        & $extract -BundlePath $signedBundle -OutputPath $restored
+    } "Burn engine output must not already exist*"
+    if ((Get-FileHash -LiteralPath $restored -Algorithm SHA256).Hash -cne $engineHash) {
+        throw "Existing extraction output was changed."
+    }
+    $rejectedOutput = Join-Path $temporaryRoot "must-not-exist.exe"
+    Assert-Rejected {
+        & $extract -BundlePath $sourceBundle -OutputPath $rejectedOutput
+    } "Missing or invalid embedded Burn engine signature bounds*"
+
+    # Mutations affect only fresh fixture copies; each must fail before writing
+    # an output. Locate the real section so both x64 and ARM64 layouts are tested.
+    $bytes = [IO.File]::ReadAllBytes($signedBundle)
+    $peOffset = [BitConverter]::ToUInt32($bytes, 0x3C)
+    $sectionTable = $peOffset + 24 + [BitConverter]::ToUInt16($bytes, $peOffset + 20)
+    $sectionCount = [BitConverter]::ToUInt16($bytes, $peOffset + 6)
+    $burnOffset = $null
+    for ($index = 0; $index -lt $sectionCount; $index++) {
+        $entry = $sectionTable + 40 * $index
+        if ([Text.Encoding]::ASCII.GetString($bytes, $entry, 8) -ceq '.wixburn') {
+            $burnOffset = [BitConverter]::ToUInt32($bytes, $entry + 20)
+        }
+    }
+    if ($null -eq $burnOffset) { throw "Fixture has no Burn section." }
+    $mutations = @(
+        @{ Name = "bad-magic"; Offset = $burnOffset; Value = 0; Error = "Unsupported .wixburn*" },
+        @{ Name = "bad-version"; Offset = $burnOffset + 4; Value = 99; Error = "Unsupported .wixburn*" },
+        @{ Name = "bad-format"; Offset = $burnOffset + 40; Value = 0; Error = "Unsupported .wixburn*" },
+        @{ Name = "missing-signature"; Offset = $burnOffset + 32; Value = 0; Error = "Missing or invalid embedded*" },
+        @{ Name = "signature-overflow"; Offset = $burnOffset + 36; Value = [uint32]::MaxValue; Error = "Missing or invalid embedded*" },
+        @{ Name = "signature-overlap"; Offset = $burnOffset + 32; Value = 64; Error = "Missing or invalid embedded*" },
+        @{ Name = "container-overflow"; Offset = $burnOffset + 44; Value = [uint32]::MaxValue; Error = "Invalid Burn attached-container count*" },
+        @{ Name = "payload-truncated"; Offset = $burnOffset + 52; Value = [uint32]::MaxValue; Error = "Truncated Burn attached payload*" },
+        @{ Name = "header-truncated"; Offset = 0x3C; Value = [uint32]::MaxValue; Error = "Truncated Burn/PE field*" }
+    )
+    foreach ($mutation in $mutations) {
+        $copy = [byte[]]$bytes.Clone()
+        [BitConverter]::GetBytes([uint32]$mutation.Value).CopyTo($copy, [int]$mutation.Offset)
+        $malformed = Join-Path $temporaryRoot "$($mutation.Name).exe"
+        [IO.File]::WriteAllBytes($malformed, $copy)
+        Assert-Rejected {
+            & $extract -BundlePath $malformed -OutputPath $rejectedOutput
+        } $mutation.Error
+        if (Test-Path -LiteralPath $rejectedOutput) { throw "Malformed bundle left an output." }
+        Write-Output "BURN_MALFORMED_REJECTED=$($mutation.Name)"
+    }
+    if (
+        (Get-FileHash -LiteralPath $sourceBundle -Algorithm SHA256).Hash -cne $sourceHash -or
+        (Get-FileHash -LiteralPath $signedBundle -Algorithm SHA256).Hash -cne $bundleHash
+    ) {
+        throw "Burn extraction changed an input bundle."
+    }
+    Write-Output "BURN_ENGINE_SIGNATURE_TESTS_OK"
+}
+finally {
+    try {
+        if ($null -ne $certificate) {
+            $certificatePath = "Cert:\CurrentUser\My\$($certificate.Thumbprint)"
+            Remove-Item -LiteralPath $certificatePath -DeleteKey -Force
+            $certificate.Dispose()
+        }
+    }
+    finally {
+        $resolvedTemporaryRoot = (Resolve-Path -LiteralPath $temporaryRoot).Path
+        if (-not $resolvedTemporaryRoot.StartsWith($safeTempRoot, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to remove a Burn test directory outside the temporary directory."
+        }
+        Remove-Item -LiteralPath $resolvedTemporaryRoot -Recurse -Force
+    }
+}

--- a/tool/verify_windows_bundle.ps1
+++ b/tool/verify_windows_bundle.ps1
@@ -177,12 +177,9 @@ New-Item -ItemType Directory -Path $payloadRoot, $baRoot -Force | Out-Null
 try {
     if ($VerifyAuthenticode) {
         $detachedEngine = Join-Path $temporaryRoot "detached-engine.exe"
-        & dotnet tool run wix -- burn detach `
-            $resolvedBundle `
-            -engine $detachedEngine | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw "WiX could not detach the signed Burn engine for verification."
-        }
+        & (Join-Path $PSScriptRoot "extract_windows_burn_engine.ps1") `
+            -BundlePath $resolvedBundle `
+            -OutputPath $detachedEngine | Out-Null
         & (Join-Path $PSScriptRoot "verify_windows_authenticode.ps1") `
             -Path $detachedEngine `
             -SignerSha256 $SignerSha256 `


### PR DESCRIPTION
## Summary

Fix the fail-closed Windows release verification failure exposed after the ICE03 fix in #64. The MSI language checks, original engine signing, and outer EXE signing succeeded, but verifying a raw `wix burn detach` result failed with no signer certificate.

WiX 5.0.2 detach copies the engine prefix without restoring the signature directory. Restore the original PE checksum/certificate directory and zero the saved fields exactly as Burn's cached-engine path does, then retain the existing Authenticode and fixed-fingerprint gates. No signer rotation or validation bypass.

Add signed inert-bundle round-trip coverage to both architecture CI jobs. The test first reproduces the former no-certificate failure, verifies byte-identical recovery of the originally signed engine, and checks tampering, wrong fingerprints, existing-output protection, missing signatures, and nine malformed metadata cases.

References: [WiX 5.0.2 detach](https://github.com/wixtoolset/wix/blob/v5.0.2/src/wix/WixToolset.Core.Burn/Inscribe/InscribeBundleEngineCommand.cs), [Burn runtime restoration](https://github.com/wixtoolset/wix/blob/v5.0.2/src/burn/engine/cache.cpp).

## Change scope

- Platforms: Windows x64-v2 and ARM64 packaging validation only.
- Outputs: none; no installer or runtime execution.
- Security or privileged-state impact: read-only bounded parsing and copying of a bundle into a new output file; no overwrite of input/existing files. The recovered engine remains subject to Authenticode and fixed signer checks. Test identities are non-exportable, temporary, and confined to CurrentUser/My; no trust-store import or official secret access. The test identity/private key and temporary copies are removed in finally blocks.
- No API, protobuf, configuration schema, version, dependency, runtime policy, third-party or frozen Go-oracle changes. v0.2.6 remains the target under the maintainer's renewed explicit retag authorization; no retag before this fix and new main pass all gates.

## Validation

Windows workstation, pinned WiX 5.0.2 and PowerShell 7; bundled Python 3.12.14:

- `python -m ruff check tool` and `python -m ruff format --check tool`.
- `python -m unittest discover -s tool -p "test_*.py" -v`: 74 passed.
- `python tool/check_repository_policy.py`.
- `python tool/release_contract.py verify-version --root . --tag v0.2.6 --android-version-code 20`.
- `cargo metadata --locked`, `actionlint -no-color`, `git diff --check`.
- `Invoke-ScriptAnalyzer -Path tool -Recurse -Settings tool/PSScriptAnalyzerSettings.psd1` and `Invoke-ScriptAnalyzer -Path tool -Recurse -IncludeRule PSUseCorrectCasing`: both passed with 1.25.0. An initial ShouldProcess finding in the test signing helper was fixed, not suppressed.
- `tool/test_windows_burn_engine.ps1 -BundlePath <inert bundle>`: passed for x64-v2 and ARM64, including byte-identical signed-engine round trip and all rejection tests.
- Complete current CI inert installer matrix rerun locally for x64-v2 and ARM64: 42 total language table/ICE checks, 40 transforms, both bundles extraction/detach/reattach, six architecture/argument-mode combinations, PowerShell 7/5.1 quiet-uninstall doubles, replacement negative tests, Japanese ICE03 regressions, and signed Burn regressions all passed.

- [x] Relevant format, lint, and unit tests pass.
- [x] The new parser has malformed-input and exact signed round-trip coverage.
- [x] New logs/errors reviewed: no private signing material or user networking data.
- [x] Documentation updated; lockfiles unchanged.

## Not tested

No MSI/EXE/APK installation or execution, live uninstall/upgrade, VPN/TUN, recovery, networking/trust mutations, or protected reliability runner tests. These remain not run, not passes. No local official signing. Rust/Flutter/Android runtime files are unchanged; fresh full PR CI/Build/CodeQL and subsequent exact-main push gates are required before retagging, rather than reusing the previous candidate's results.

## Checklist

- [x] Conventional Commit title.
- [x] No signing key, token, generated package, or diagnostics committed.
- [x] No WebView UI, insecure TLS, automatic telemetry or diagnostic upload.
- [x] Read CONTRIBUTING.md, SECURITY.md, and Code of Conduct.
